### PR TITLE
Fix mypy types in edge plugin

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -84,7 +84,7 @@ class StreamEdge(EdgeTransport):
         if not event.payload:
             return
 
-        if event.participant.user_id:
+        if event.participant and event.participant.user_id:
             session_id = event.participant.session_id
             user_id = event.participant.user_id
         else:
@@ -170,7 +170,7 @@ class StreamEdge(EdgeTransport):
             event_desc = "Track unpublished"
         else:
             # ParticipantLeftEvent - all published tracks
-            tracks_to_remove = event.participant.published_tracks or []
+            tracks_to_remove = (event.participant.published_tracks if event.participant else None) or []
             event_desc = "Participant left"
         
         track_names = [TrackType.Name(t) for t in tracks_to_remove]

--- a/plugins/silero/tests/test_vad.py
+++ b/plugins/silero/tests/test_vad.py
@@ -446,16 +446,18 @@ async def test_silence_no_turns():
     async def on_audio(event: VADAudioEvent):
         nonlocal audio_event_fired
         audio_event_fired = True
+        duration_sec = (event.duration_ms / 1000.0) if event.duration_ms is not None else 0.0
         logger.info(
-            f"Audio event detected on silence! Duration: {event.duration_ms / 1000.0:.2f}s"
+            f"Audio event detected on silence! Duration: {duration_sec:.2f}s"
         )
 
     @vad.events.subscribe
     async def on_partial(event: VADPartialEvent):
         nonlocal partial_event_fired
         partial_event_fired = True
+        duration_sec = (event.duration_ms / 1000.0) if event.duration_ms is not None else 0.0
         logger.info(
-            f"Partial event detected on silence! Duration: {event.duration_ms / 1000.0:.2f}s"
+            f"Partial event detected on silence! Duration: {duration_sec:.2f}s"
         )
 
     # Process the silence in chunks to simulate streaming


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability when publishing/removing tracks by safely handling missing participants and falling back to payload user/session IDs.
  - Prevented errors when participant data or published tracks are absent, reducing edge-case failures.

- Tests
  - Refined VAD test logging to safely compute and display durations in seconds, improving clarity without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->