### PR TITLE
Fix default channel type

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -55,7 +55,7 @@ class StreamEdge(EdgeTransport):
         self.events.register_events_from_module(sfu_events)
         self.channel: Optional[Channel] = None
         self.conversation: Optional[StreamConversation] = None
-        self.channel_type = "default"
+        self.channel_type = "messaging"
         self.agent_user_id: str | None = None
         # Track mapping: (user_id, session_id, track_type_int) -> {"track_id": str, "published": bool}
         # track_type_int is from TrackType enum (e.g., TrackType.TRACK_TYPE_AUDIO)


### PR DESCRIPTION
Use the `messaging` channel type so chat integration works out of the box without provisioning a custom channel type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - New conversations now default to a messaging channel type, offering a chat-first experience when starting a conversation.
  - Video calls remain available when explicitly initiated; this change does not alter existing call controls or event behavior.
  - Users may notice that starting a new conversation no longer opens a video session by default, reducing accidental call starts and aligning the default flow with typical messaging use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->