### PR TITLE
fix: Update .env.example for Gemini Live

### DIFF
--- a/examples/other_examples/gemini_live_realtime/.env.example
+++ b/examples/other_examples/gemini_live_realtime/.env.example
@@ -3,5 +3,6 @@ STREAM_API_KEY=your_stream_api_key_here
 STREAM_API_SECRET=your_stream_api_secret_here
 EXAMPLE_BASE_URL=https://pronto.getstream.io
 
-# Deepgram API credentials
-DEEPGRAM_API_KEY=your_deepgram_api_key_here
+# Google/Gemini
+# Get your key from: https://aistudio.google.com/app/apikey
+GOOGLE_API_KEY=your_google_gemini_key


### PR DESCRIPTION
Fixes the Gemini example .env file. I don't think it should reference DEEPGRAM_API_KEY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example environment configuration to use Google/Gemini API credentials instead of Deepgram API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->