### PR TITLE
test(aws): run normalize tests without Bedrock fixture

### DIFF
--- a/plugins/aws/tests/test_aws.py
+++ b/plugins/aws/tests/test_aws.py
@@ -49,7 +49,7 @@ class TestBedrockLLM:
         return llm
 
     @pytest.mark.asyncio
-    async def test_message(self, llm: BedrockLLM):
+    async def test_message(self):
         messages = BedrockLLM._normalize_message("say hi")
         assert isinstance(messages[0], Message)
         message = messages[0]
@@ -57,7 +57,7 @@ class TestBedrockLLM:
         assert message.content == "say hi"
 
     @pytest.mark.asyncio
-    async def test_advanced_message(self, llm: BedrockLLM):
+    async def test_advanced_message(self):
         advanced = {
             "role": "user",
             "content": [{"text": "Explain quantum entanglement in simple terms."}],


### PR DESCRIPTION
These tests only exercise `BedrockLLM._normalize_message`, but the shared `llm` fixture bootstrapped a real Bedrock client and demanded AWS credentials. That made the “not integration” target fail despite filtering integration markers. Dropping the unused fixture keeps the tests offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test method signatures in AWS plugin tests through improved pytest fixture injection.

**Note:** This is an internal test refactoring with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->