### PR TITLE
Fix participant forwarding with turn detection enabled

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -1058,14 +1058,8 @@ class Agent:
                     f"🤖 Triggering LLM response after turn ended for {event.participant.user_id}"
                 )
 
-                # Create participant object if we have metadata
-                participant = event.participant
-                if event.custom:
-                    # Try to extract participant info from custom metadata
-                    participant = event.custom.get("participant")
-
                 # Trigger LLM response with the complete transcript
-                await self.simple_response(transcript, participant)
+                await self.simple_response(transcript, event.participant)
 
                 # Clear the pending transcript for this speaker
                 self._pending_user_transcripts[event.participant.user_id] = ""


### PR DESCRIPTION
**Problem:**
`LLM.simple_response()` is always called with `participant=None` when turn detection is used.

Always passing the participant from the event should fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined agent event processing logic for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->