### PR TITLE
Tell cursor to avoid hasattr

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -9,6 +9,7 @@ tests use pytest.
 never adjust sys.path.
 
 never write: except Exception as e
+avoid using getattr, hasattr, delattr and setattr; prefer normal attribute access.
 
 docs should be short.
 docstrings should follow the google style guides for docstrings.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python development guidelines to recommend standard attribute access patterns over alternative methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->