### PR TITLE
Added names to moondream processors to fix errors

### DIFF
--- a/plugins/moondream/vision_agents/plugins/moondream/detection/moondream_cloud_processor.py
+++ b/plugins/moondream/vision_agents/plugins/moondream/detection/moondream_cloud_processor.py
@@ -45,6 +45,7 @@ class CloudDetectionProcessor(AudioVideoProcessor, VideoProcessorMixin, VideoPub
         interval: Processing interval in seconds (default: 0)
         max_workers: Number of worker threads for CPU-intensive operations (default: 10)
     """
+    name = "moondream_cloud"
     
     def __init__(
         self,

--- a/plugins/moondream/vision_agents/plugins/moondream/detection/moondream_local_processor.py
+++ b/plugins/moondream/vision_agents/plugins/moondream/detection/moondream_local_processor.py
@@ -51,6 +51,7 @@ class LocalDetectionProcessor(AudioVideoProcessor, VideoProcessorMixin, VideoPub
         options: AgentOptions for model directory configuration. If not provided,
                  uses default_agent_options() which defaults to tempfile.gettempdir()
     """
+    name = "moondream_local"
 
     def __init__(
             self,


### PR DESCRIPTION
When running both the `LocalDetectionProcessor` and the `CloudDetectionProcessor` I'm getting errors due to the missing name. This fixes that and lets me run the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added name identifiers to cloud and local detection processors within the Moondream plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->