### PR TITLE
Remove llm response text from tracing

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -450,12 +450,10 @@ class Agent:
         """
         self.logger.info('🤖 Asking LLM to reply to "%s"', text)
         with self.tracer.start_as_current_span("simple_response") as span:
-            response = await self.llm.simple_response(
+            await self.llm.simple_response(
                 text=text, processors=self.processors, participant=participant
             )
             span.set_attribute("text", text)
-            span.set_attribute("response.text", response.text)
-            span.set_attribute("response.original", response.original)
 
     async def simple_audio_response(
         self, pcm: PcmData, participant: Optional[Participant] = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified LLM response handling by removing response capture from tracing operations, reducing metadata overhead while maintaining core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->