### PR TITLE
Fix blockbuster failing on blocking calls inside Agent.__init__

### DIFF
--- a/agents-core/vision_agents/core/llm/llm.py
+++ b/agents-core/vision_agents/core/llm/llm.py
@@ -176,8 +176,21 @@ class LLM(abc.ABC):
         """
         self._conversation = conversation
 
-    def set_instructions(self, instructions: Instructions):
-        self._instructions = instructions.full_reference
+    def set_instructions(self, instructions: Instructions | str) -> None:
+        """
+        Set instructions for LLM.
+
+        Args:
+            instructions: instructions object. Can be either `str` or `Instructions`.
+        """
+        if isinstance(instructions, str):
+            self._instructions = instructions
+        elif isinstance(instructions, Instructions):
+            self._instructions = instructions.full_reference
+        else:
+            raise TypeError(
+                f"Invalid instructions type {type(instructions)}, expected str or Instructions"
+            )
 
     def register_function(
         self, name: Optional[str] = None, description: Optional[str] = None

--- a/plugins/aws/tests/test_aws.py
+++ b/plugins/aws/tests/test_aws.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 
 from vision_agents.core.agents.conversation import InMemoryConversation
 from vision_agents.core.agents.conversation import Message
-from vision_agents.core.instructions import Instructions
 from vision_agents.core.llm.events import LLMResponseChunkEvent
 from vision_agents.plugins.aws.aws_llm import BedrockLLM
 
@@ -147,7 +146,7 @@ class TestBedrockLLM:
             model="qwen.qwen3-32b-v1:0",
             region_name="us-east-1",
         )
-        llm.set_instructions(Instructions("only reply in 2 letter country shortcuts"))
+        llm.set_instructions("only reply in 2 letter country shortcuts")
 
         response = await llm.simple_response(
             text="Which country is rainy, protected from water with dikes and below sea level?",

--- a/plugins/aws/tests/test_aws_realtime.py
+++ b/plugins/aws/tests/test_aws_realtime.py
@@ -4,7 +4,6 @@ import asyncio
 import pytest
 from dotenv import load_dotenv
 
-from vision_agents.core.instructions import Instructions
 from vision_agents.core.tts.manual_test import play_pcm_with_ffplay
 from vision_agents.plugins.aws import Realtime
 from vision_agents.core.llm.events import RealtimeAudioOutputEvent
@@ -25,9 +24,7 @@ class TestBedrockRealtime:
             model="amazon.nova-sonic-v1:0",
             region_name="us-east-1",
         )
-        realtime.set_instructions(
-            Instructions("you're a kind assistant, always be friendly please.")
-        )
+        realtime.set_instructions("you're a kind assistant, always be friendly please.")
         try:
             yield realtime
         finally:
@@ -38,7 +35,7 @@ class TestBedrockRealtime:
         # unlike other realtime LLMs, AWS doesn't reply if you only send text
         events = []
         realtime.set_instructions(
-            Instructions("whenever you reply mention a fun fact about The Netherlands")
+            "whenever you reply mention a fun fact about The Netherlands"
         )
 
         @realtime.events.subscribe

--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -3,7 +3,6 @@ from dotenv import load_dotenv
 
 
 from vision_agents.core.agents.conversation import InMemoryConversation, Message
-from vision_agents.core.instructions import Instructions
 
 from vision_agents.plugins.gemini.gemini_llm import GeminiLLM
 from vision_agents.core.llm.events import (
@@ -85,7 +84,7 @@ class TestGeminiLLM:
         llm = GeminiLLM(model="gemini-2.0-flash-exp")
         llm.set_conversation(InMemoryConversation("be friendly", []))
 
-        llm.set_instructions(Instructions("only reply in 2 letter country shortcuts"))
+        llm.set_instructions("only reply in 2 letter country shortcuts")
 
         response = await llm.simple_response(
             text="Which country is rainy, protected from water with dikes and below sea level?",

--- a/plugins/openai/tests/test_openai_realtime.py
+++ b/plugins/openai/tests/test_openai_realtime.py
@@ -2,7 +2,6 @@ import asyncio
 import pytest
 from dotenv import load_dotenv
 
-from vision_agents.core.instructions import Instructions
 from vision_agents.plugins.openai import Realtime
 from vision_agents.core.llm.events import (
     RealtimeAudioOutputEvent,
@@ -24,7 +23,7 @@ class TestOpenAIRealtime:
             model="gpt-realtime",
             voice="alloy",
         )
-        realtime.set_instructions(Instructions("be friendly"))
+        realtime.set_instructions("be friendly")
         try:
             yield realtime
         finally:

--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -468,7 +468,7 @@ class Realtime(realtime.Realtime):
         except Exception as e:
             logger.error(f"Failed to send tool response: {e}")
 
-    def set_instructions(self, instructions: Instructions):
+    def set_instructions(self, instructions: Instructions | str) -> None:
         super().set_instructions(instructions)
         self.realtime_session["instructions"] = self._instructions
 


### PR DESCRIPTION
`BlockBuster` fails some integration tests because `Instructions` object parses markdown files on `__init__` in a blocking way.
Making it non-blocking would be more clunky and require more code, and it's ok for `Instructions.__init__` to be blocking since it's created once and before any async work.

So the solution is:
- To skip BlockBuster checks for all `Agent.__init__`.
- To allow `LLM.set_instructions()` to accept plain `str`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * LLM instruction-setting methods now accept plain strings in addition to structured instruction objects, simplifying API usage and improving flexibility across all LLM providers.

* **Tests**
  * Updated test suite to validate the enhanced instruction API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->