### PR TITLE
Remove redundant warning in Agent turn detection

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -1095,9 +1095,6 @@ class Agent:
             if not event.eager_end_of_turn:
                 buffer.reset()
 
-            if not transcript.strip():
-                self.logger.warning("Turn ended with no transcript, like STT is broken")
-
             if transcript.strip():
                 # cancel the old task if the text changed in the meantime
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary warning logs that appeared during agent turns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->