### PR TITLE
fix: subscribe to existing participant tracks when agent joins late

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -136,24 +136,25 @@ class StreamEdge(EdgeTransport):
                 except Exception as e:
                     logger.error(f"Failed to subscribe to existing track: {e}")
 
-        # Wait for WebRTC tracks to arrive after subscription
-        if tracks_to_subscribe:
-            await asyncio.sleep(1.0)
+        # Poll for WebRTC tracks to arrive after subscription
+        for participant, track_type_int in tracks_to_subscribe:
+            expected_kind = self._get_webrtc_kind(track_type_int)
+            track_key = (
+                participant.user_id,
+                participant.session_id,
+                track_type_int,
+            )
 
-            # Emit TrackAddedEvent for each track that arrived
-            for participant, track_type_int in tracks_to_subscribe:
-                expected_kind = self._get_webrtc_kind(track_type_int)
-                track_key = (
-                    participant.user_id,
-                    participant.session_id,
-                    track_type_int,
-                )
+            if track_key in self._track_map:
+                continue
 
-                if track_key in self._track_map:
-                    continue
+            # Poll for WebRTC track ID with timeout (same pattern as _on_track_published)
+            track_id = None
+            timeout = 10.0
+            poll_interval = 0.01
+            elapsed = 0.0
 
-                # Find the WebRTC track ID from pending tracks
-                track_id = None
+            while elapsed < timeout:
                 for tid, (pending_user, pending_session, pending_kind) in list(
                     self._pending_tracks.items()
                 ):
@@ -167,26 +168,32 @@ class StreamEdge(EdgeTransport):
                         break
 
                 if track_id:
-                    self._track_map[track_key] = {
-                        "track_id": track_id,
-                        "published": True,
-                    }
-                    sfu_participant = SfuParticipant.from_proto(participant)
+                    break
 
-                    self.events.send(
-                        events.TrackAddedEvent(
-                            plugin_name="getstream",
-                            track_id=track_id,
-                            track_type=track_type_int,
-                            user=sfu_participant,
-                            participant=sfu_participant,
-                        )
+                await asyncio.sleep(poll_interval)
+                elapsed += poll_interval
+
+            if track_id:
+                self._track_map[track_key] = {
+                    "track_id": track_id,
+                    "published": True,
+                }
+                sfu_participant = SfuParticipant.from_proto(participant)
+
+                self.events.send(
+                    events.TrackAddedEvent(
+                        plugin_name="getstream",
+                        track_id=track_id,
+                        track_type=track_type_int,
+                        user=sfu_participant,
+                        participant=sfu_participant,
                     )
-                else:
-                    logger.warning(
-                        f"No pending track for existing participant: "
-                        f"user={participant.user_id}, type={TrackType.Name(track_type_int)}"
-                    )
+                )
+            else:
+                logger.warning(
+                    f"No pending track for existing participant: "
+                    f"user={participant.user_id}, type={TrackType.Name(track_type_int)}"
+                )
 
     async def _on_track_published(self, event: sfu_events.TrackPublishedEvent):
         """Handle track published events from SFU - spawn TrackAddedEvent with correct type."""


### PR DESCRIPTION
When the agent joins a call after users are already present, the TrackPublished events were already sent before the agent connected. This caused the agent to miss video tracks from existing participants.

The fix manually triggers subscriptions for existing participants' published tracks after the connection is established, then emits TrackAddedEvent once the WebRTC tracks arrive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where the agent could not subscribe to media tracks from participants who joined before it connected.
  * Improved track synchronization and event handling so audio/video streams from existing participants are discovered, matched, and processed more reliably, with safer timeout and error handling when delayed or missing tracks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->