### PR TITLE
fix: prevent duplicate messages in conversation for Realtime LLM

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -401,6 +401,12 @@ class Agent:
             if self.conversation is None or not event.text:
                 return
 
+            # Skip syncing to conversation in Realtime mode - LLMResponseCompletedEvent
+            # already handles this via on_llm_response_sync_conversation. The agent speech
+            # transcription would create a duplicate message with the same content.
+            if _is_audio_llm(self.llm):
+                return
+
             with self.span("agent.on_realtime_agent_speech_transcription"):
                 await self.conversation.upsert_message(
                     message_id=str(uuid.uuid4()),


### PR DESCRIPTION
Skip syncing agent speech transcription to conversation when using a Realtime LLM since LLMResponseCompletedEvent already handles this via on_llm_response_sync_conversation. This prevents duplicate messages with the same content being added to the conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where duplicate messages were generated in Realtime mode when using audio-enabled language models, improving conversation consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->