### PR TITLE
fix(plugins:getstream): Use python 3.10 compatible timezone

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -417,10 +417,10 @@ class StreamEdge(EdgeTransport):
                         # TODO: get rid of this when codegen for stream-py is fixed, these fields are meaningless
                         banned=False,
                         channel_role="",
-                        created_at=datetime.datetime.now(datetime.UTC),
+                        created_at=datetime.datetime.now(datetime.timezone.utc),
                         notifications_muted=False,
                         shadow_banned=False,
-                        updated_at=datetime.datetime.now(datetime.UTC),
+                        updated_at=datetime.datetime.now(datetime.timezone.utc),
                         custom={},
                     )
                 ]


### PR DESCRIPTION
# Description

The datetime.UTC alias was only added in python 3.11

# Fixes
- #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed timezone handling in timestamp operations to prevent potential errors. Timestamp fields now use correct timezone specifications for reliable date-time processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->