### PR TITLE
fix: SDK usage statistics tracking for vision-agents

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -107,7 +107,7 @@ class StreamEdge(EdgeTransport):
         # Initialize Stream client
         super().__init__()
         version = get_vision_agents_version()
-        self.client = AsyncStream(user_agent=f"vision-agents-{version}")
+        self.client = AsyncStream(user_agent=f"stream-vision-agents-{version}")
         self.events = EventManager()
         self.events.register_events_from_module(events)
         self.events.register_events_from_module(sfu_events)


### PR DESCRIPTION
## Summary
- Add `stream-` prefix to user_agent so vision-agents API calls are tracked in SDK usage statistics
- The chat backend's SDK stats collector requires the `X-Stream-Client` header to match the pattern `stream-*-MAJOR.MINOR.PATCH`
- Previously `vision-agents-{version}` was used, which didn't match and was silently ignored

## Details
The `X-Stream-Client` header is parsed by [`chat/server/sdkstats/sdk_stats.go`](https://github.com/GetStream/chat/blob/master/server/sdkstats/sdk_stats.go#L28) using regex:
```
^(stream-[a-zA-Z\-]+)-v?(\d+)\.(\d+)\.(\d+)
```

This change updates the user agent from `vision-agents-1.0.0` to `stream-vision-agents-1.0.0` so it matches the expected pattern.

## Test plan
- [ ] Verify API calls from vision-agents appear in SDK usage statistics after deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal client identification to enhance service compatibility and tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->