### PR TITLE
feat: add custom events and metrics broadcasting via Stream Video

### DIFF
--- a/agents-core/vision_agents/core/edge/edge_transport.py
+++ b/agents-core/vision_agents/core/edge/edge_transport.py
@@ -59,3 +59,12 @@ class EdgeTransport(AsyncIOEventEmitter, abc.ABC):
         self, track_id: str
     ) -> Optional[aiortc.mediastreams.MediaStreamTrack]:
         pass
+
+    @abc.abstractmethod
+    async def send_custom_event(self, data: dict[str, Any]) -> None:
+        """Send a custom event to all participants watching the call.
+
+        Args:
+            data: Custom event payload (must be JSON-serializable, max 5KB).
+        """
+        pass

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -7561,7 +7561,6 @@ dev = [
 
 [[package]]
 name = "vision-agents-plugins-twilio"
-version = "0.1.0"
 source = { editable = "plugins/twilio" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Add ability to send custom events and metrics to call participants through Stream Video's custom events API. This enables building real-time dashboards in client apps.

- Add send_custom_event() to EdgeTransport and StreamEdge
- Add send_custom_event() and send_metrics_event() to Agent
- Add broadcast_metrics and broadcast_metrics_interval constructor params for automatic periodic metrics broadcasting
- Store Call reference in StreamEdge for event sending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now broadcast performance metrics to call participants with configurable intervals.
  * Added public APIs for sending custom events and metric snapshots to all connected participants.
  * New configuration options to enable metrics broadcasting and control broadcast frequency.

* **Tests**
  * Added comprehensive test coverage for metrics broadcasting and custom event functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->