### PR TITLE
Fix `Task exception was never retrieved` in Agent._poll_audio_queues on close

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -1097,30 +1097,19 @@ class Agent:
         self,
         queues: dict[str, tuple[Participant, AudioQueue]],
     ) -> AsyncIterator[tuple[Participant, PcmData]]:
-        """Poll all participant audio queues in parallel.
+        """Poll all participant audio queues sequentially.
 
-        Yields (Participant, PcmData) tuples as each queue produces a chunk.
-        Queues that time out are silently skipped. On exit, any remaining
-        in-flight tasks are cancelled to avoid unhandled exceptions.
+        Yields (Participant, PcmData) tuples for each queue that has data ready.
+        Queues that time out are silently skipped.
         """
-
-        async def _poll(participant: Participant, queue: AudioQueue):
-            pcm = await asyncio.wait_for(
-                queue.get_duration(duration_ms=20), timeout=0.001
-            )
-            return participant, pcm
-
-        tasks = [asyncio.create_task(_poll(p, q)) for p, q in queues.values()]
-        try:
-            for fut in asyncio.as_completed(tasks):
-                try:
-                    yield await fut
-                except (asyncio.TimeoutError, asyncio.QueueEmpty):
-                    continue
-        finally:
-            for t in tasks:
-                if not t.done():
-                    t.cancel()
+        for participant, queue in queues.values():
+            try:
+                pcm = await asyncio.wait_for(
+                    queue.get_duration(duration_ms=20), timeout=0.001
+                )
+                yield participant, pcm
+            except (TimeoutError, asyncio.QueueEmpty):
+                continue
 
     async def _consume_incoming_audio(self) -> None:
         """Consumer that continuously processes audio from per-participant queues."""


### PR DESCRIPTION
`Agent._poll_audio_queues` sometimes triggered `Task exception was never retrieved` warnings on `Agent.close` because participant queues were polled in parallel in background tasks.

This PR simplifies the code by making the poll sequential since the timeout is only 1ms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the audio queue polling mechanism by changing from concurrent to sequential processing, improving code maintainability and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->