### PR TITLE
feat(events): establish outbound connection-event architecture

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -34,7 +34,6 @@ from ..edge.types import Connection, Participant, TrackType, User
 from ..events import (
     AgentConnectionEvent,
     EdgeCustomEventOutboundAdapter,
-    InboundConnectionEvent,
 )
 from ..events.bus import EventBus, EventHandler, InMemoryEventBus
 from ..events.manager import EventManager
@@ -152,8 +151,6 @@ class Agent:
         multi_speaker_filter: Optional[AudioFilter] = None,
         # Outbound event bus for external-facing events.
         outbound_bus: EventBus[AgentConnectionEvent] | None = None,
-        # Inbound event bus for external events coming into the agent.
-        inbound_bus: EventBus[InboundConnectionEvent] | None = None,
         # Whether to auto-register edge custom-event adapter on join.
         auto_register_edge_outbound_adapter: bool = True,
     ):
@@ -185,7 +182,6 @@ class Agent:
                 everyone else until the active speaker's turn ends, or they go
                 silent.
             outbound_bus: Optional outbound event bus implementation.
-            inbound_bus: Optional inbound event bus implementation.
             auto_register_edge_outbound_adapter: If True, the agent registers
                 a default adapter that forwards outbound events to
                 `edge.send_custom_event()` when joining a call.
@@ -231,7 +227,6 @@ class Agent:
         self.events.register_events_from_module(events)
         self.events.register_events_from_module(llm_events)
         self.outbound_events = outbound_bus or InMemoryEventBus[AgentConnectionEvent]()
-        self.inbound_events = inbound_bus or InMemoryEventBus[InboundConnectionEvent]()
         self._auto_register_edge_outbound_adapter = auto_register_edge_outbound_adapter
         self._edge_outbound_adapter = EdgeCustomEventOutboundAdapter(self.edge)
         self._edge_outbound_adapter_registered = False
@@ -1546,14 +1541,22 @@ class Agent:
         self.register_outbound_adapter(self._edge_outbound_adapter)
         self._edge_outbound_adapter_registered = True
 
+    def _require_adapter_method(
+        self, adapter: Any, method_name: str, error_message: str
+    ) -> Any:
+        method = getattr(adapter, method_name, None)
+        if method is None:
+            raise ValueError(error_message)
+        return method
+
     def _resolve_adapter_deliver(
         self, adapter: OutboundEventAdapter
     ) -> EventHandler[AgentConnectionEvent]:
-        deliver = getattr(adapter, "deliver", None)
-        if deliver is None:
-            raise ValueError(
-                "Outbound adapter must define an async deliver(event) method"
-            )
+        deliver: EventHandler[AgentConnectionEvent] = self._require_adapter_method(
+            adapter,
+            "deliver",
+            "Outbound adapter must define an async deliver(event) method",
+        )
         return deliver
 
     def register_outbound_adapter(self, adapter: OutboundEventAdapter) -> None:
@@ -1564,16 +1567,6 @@ class Agent:
     async def send_event(self, event: AgentConnectionEvent) -> None:
         """Publish an external-facing event to the outbound event bus."""
         await self.outbound_events.publish(event)
-
-    def register_inbound_handler(
-        self, handler: EventHandler[InboundConnectionEvent]
-    ) -> None:
-        """Register a handler for external events delivered to the agent."""
-        self.inbound_events.subscribe(handler)
-
-    async def receive_event(self, event: InboundConnectionEvent) -> None:
-        """Publish an external inbound event to the inbound event bus."""
-        await self.inbound_events.publish(event)
 
     async def send_custom_event(self, data: dict) -> None:
         """Send a custom event to all participants watching the call.

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -30,6 +30,8 @@ from ..edge.events import (
     TrackRemovedEvent,
 )
 from ..edge.types import Connection, Participant, TrackType, User
+from ..events import AgentConnectionEvent
+from ..events.bus import EventBus, InMemoryEventBus
 from ..events.manager import EventManager
 from ..instructions import Instructions
 from ..llm import events as llm_events
@@ -139,6 +141,8 @@ class Agent:
         broadcast_metrics_interval: float = 5.0,
         # Audio filter to process audio from multiple speakers
         multi_speaker_filter: Optional[AudioFilter] = None,
+        # Outbound event bus for external-facing events.
+        outbound_bus: EventBus[AgentConnectionEvent] | None = None,
     ):
         """Initialize the Agent.
 
@@ -208,6 +212,7 @@ class Agent:
         self.events = EventManager()
         self.events.register_events_from_module(events)
         self.events.register_events_from_module(llm_events)
+        self.outbound_events = outbound_bus or InMemoryEventBus[AgentConnectionEvent]()
 
         self.llm = llm
         self.stt = stt
@@ -1509,6 +1514,19 @@ class Agent:
     @property
     def metrics(self) -> AgentMetrics:
         return self._metrics
+
+    def register_outbound_adapter(self, adapter: Any) -> None:
+        """Register an outbound adapter that receives AgentConnectionEvent events."""
+        deliver = getattr(adapter, "deliver", None)
+        if deliver is None:
+            raise ValueError(
+                "Outbound adapter must define an async deliver(event) method"
+            )
+        self.outbound_events.subscribe(deliver)
+
+    async def send_event(self, event: AgentConnectionEvent) -> None:
+        """Publish an external-facing event to the outbound event bus."""
+        await self.outbound_events.publish(event)
 
     async def send_custom_event(self, data: dict) -> None:
         """Send a custom event to all participants watching the call.

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 import time
 import uuid
-from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import (
@@ -33,7 +32,7 @@ from ..edge.events import (
 )
 from ..edge.types import Connection, Participant, TrackType, User
 from ..events import AgentConnectionEvent, EdgeCustomEventOutboundAdapter
-from ..events.bus import EventBus, InMemoryEventBus
+from ..events.bus import EventBus, EventHandler, InMemoryEventBus
 from ..events.manager import EventManager
 from ..instructions import Instructions
 from ..llm import events as llm_events
@@ -1541,7 +1540,7 @@ class Agent:
 
     def _resolve_adapter_deliver(
         self, adapter: OutboundEventAdapter
-    ) -> Callable[[AgentConnectionEvent], Awaitable[None]]:
+    ) -> EventHandler[AgentConnectionEvent]:
         deliver = getattr(adapter, "deliver", None)
         if deliver is None:
             raise ValueError(

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import (
@@ -10,6 +11,7 @@ from typing import (
     AsyncIterator,
     Iterator,
     Optional,
+    Protocol,
     TypeGuard,
 )
 from uuid import uuid4
@@ -30,7 +32,7 @@ from ..edge.events import (
     TrackRemovedEvent,
 )
 from ..edge.types import Connection, Participant, TrackType, User
-from ..events import AgentConnectionEvent
+from ..events import AgentConnectionEvent, EdgeCustomEventOutboundAdapter
 from ..events.bus import EventBus, InMemoryEventBus
 from ..events.manager import EventManager
 from ..instructions import Instructions
@@ -79,6 +81,10 @@ from .transcript import TranscriptStore
 logger = logging.getLogger(__name__)
 
 tracer: Tracer = trace.get_tracer("agents")
+
+
+class OutboundEventAdapter(Protocol):
+    async def deliver(self, event: AgentConnectionEvent) -> None: ...
 
 
 class Agent:
@@ -143,6 +149,8 @@ class Agent:
         multi_speaker_filter: Optional[AudioFilter] = None,
         # Outbound event bus for external-facing events.
         outbound_bus: EventBus[AgentConnectionEvent] | None = None,
+        # Whether to auto-register edge custom-event adapter on join.
+        auto_register_edge_outbound_adapter: bool = True,
     ):
         """Initialize the Agent.
 
@@ -171,6 +179,10 @@ class Agent:
                 the first participant who starts speaking and drops audio from
                 everyone else until the active speaker's turn ends, or they go
                 silent.
+            outbound_bus: Optional outbound event bus implementation.
+            auto_register_edge_outbound_adapter: If True, the agent registers
+                a default adapter that forwards outbound events to
+                `edge.send_custom_event()` when joining a call.
 
         """
         self._agent_user_initialized = False
@@ -213,6 +225,9 @@ class Agent:
         self.events.register_events_from_module(events)
         self.events.register_events_from_module(llm_events)
         self.outbound_events = outbound_bus or InMemoryEventBus[AgentConnectionEvent]()
+        self._auto_register_edge_outbound_adapter = auto_register_edge_outbound_adapter
+        self._edge_outbound_adapter = EdgeCustomEventOutboundAdapter(self.edge)
+        self._edge_outbound_adapter_registered = False
 
         self.llm = llm
         self.stt = stt
@@ -687,6 +702,7 @@ class Agent:
             await self.authenticate()
             with self.span("edge.join"):
                 self._connection = await self.edge.join(self, call)
+            self._register_default_outbound_adapter_if_needed()
             self.logger.info(f"🤖 Agent joined call: {call.id}")
 
             # Set up audio and video tracks together to avoid SDP issues
@@ -1515,13 +1531,27 @@ class Agent:
     def metrics(self) -> AgentMetrics:
         return self._metrics
 
-    def register_outbound_adapter(self, adapter: Any) -> None:
-        """Register an outbound adapter that receives AgentConnectionEvent events."""
+    def _register_default_outbound_adapter_if_needed(self) -> None:
+        if not self._auto_register_edge_outbound_adapter:
+            return
+        if self._edge_outbound_adapter_registered:
+            return
+        self.register_outbound_adapter(self._edge_outbound_adapter)
+        self._edge_outbound_adapter_registered = True
+
+    def _resolve_adapter_deliver(
+        self, adapter: OutboundEventAdapter
+    ) -> Callable[[AgentConnectionEvent], Awaitable[None]]:
         deliver = getattr(adapter, "deliver", None)
         if deliver is None:
             raise ValueError(
                 "Outbound adapter must define an async deliver(event) method"
             )
+        return deliver
+
+    def register_outbound_adapter(self, adapter: OutboundEventAdapter) -> None:
+        """Register an outbound adapter that receives AgentConnectionEvent events."""
+        deliver = self._resolve_adapter_deliver(adapter)
         self.outbound_events.subscribe(deliver)
 
     async def send_event(self, event: AgentConnectionEvent) -> None:

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -31,7 +31,11 @@ from ..edge.events import (
     TrackRemovedEvent,
 )
 from ..edge.types import Connection, Participant, TrackType, User
-from ..events import AgentConnectionEvent, EdgeCustomEventOutboundAdapter
+from ..events import (
+    AgentConnectionEvent,
+    EdgeCustomEventOutboundAdapter,
+    InboundConnectionEvent,
+)
 from ..events.bus import EventBus, EventHandler, InMemoryEventBus
 from ..events.manager import EventManager
 from ..instructions import Instructions
@@ -148,6 +152,8 @@ class Agent:
         multi_speaker_filter: Optional[AudioFilter] = None,
         # Outbound event bus for external-facing events.
         outbound_bus: EventBus[AgentConnectionEvent] | None = None,
+        # Inbound event bus for external events coming into the agent.
+        inbound_bus: EventBus[InboundConnectionEvent] | None = None,
         # Whether to auto-register edge custom-event adapter on join.
         auto_register_edge_outbound_adapter: bool = True,
     ):
@@ -179,6 +185,7 @@ class Agent:
                 everyone else until the active speaker's turn ends, or they go
                 silent.
             outbound_bus: Optional outbound event bus implementation.
+            inbound_bus: Optional inbound event bus implementation.
             auto_register_edge_outbound_adapter: If True, the agent registers
                 a default adapter that forwards outbound events to
                 `edge.send_custom_event()` when joining a call.
@@ -224,6 +231,7 @@ class Agent:
         self.events.register_events_from_module(events)
         self.events.register_events_from_module(llm_events)
         self.outbound_events = outbound_bus or InMemoryEventBus[AgentConnectionEvent]()
+        self.inbound_events = inbound_bus or InMemoryEventBus[InboundConnectionEvent]()
         self._auto_register_edge_outbound_adapter = auto_register_edge_outbound_adapter
         self._edge_outbound_adapter = EdgeCustomEventOutboundAdapter(self.edge)
         self._edge_outbound_adapter_registered = False
@@ -1556,6 +1564,16 @@ class Agent:
     async def send_event(self, event: AgentConnectionEvent) -> None:
         """Publish an external-facing event to the outbound event bus."""
         await self.outbound_events.publish(event)
+
+    def register_inbound_handler(
+        self, handler: EventHandler[InboundConnectionEvent]
+    ) -> None:
+        """Register a handler for external events delivered to the agent."""
+        self.inbound_events.subscribe(handler)
+
+    async def receive_event(self, event: InboundConnectionEvent) -> None:
+        """Publish an external inbound event to the inbound event bus."""
+        await self.inbound_events.publish(event)
 
     async def send_custom_event(self, data: dict) -> None:
         """Send a custom event to all participants watching the call.

--- a/agents-core/vision_agents/core/events/__init__.py
+++ b/agents-core/vision_agents/core/events/__init__.py
@@ -3,6 +3,7 @@ from .base import (
     AudioFormat,
     BaseEvent,
     ConnectionState,
+    InboundConnectionEvent,
     PluginBaseEvent,
     VideoProcessorDetectionEvent,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "EventBus",
     "EventHandler",
     "EventManager",
+    "InboundConnectionEvent",
     "InMemoryEventBus",
     "PluginBaseEvent",
     "VideoProcessorDetectionEvent",

--- a/agents-core/vision_agents/core/events/__init__.py
+++ b/agents-core/vision_agents/core/events/__init__.py
@@ -1,17 +1,22 @@
 from .base import (
+    AgentConnectionEvent,
     AudioFormat,
     BaseEvent,
     ConnectionState,
     PluginBaseEvent,
     VideoProcessorDetectionEvent,
 )
+from .bus import EventBus, InMemoryEventBus
 from .manager import EventManager
 
 __all__ = [
+    "AgentConnectionEvent",
     "AudioFormat",
     "BaseEvent",
     "ConnectionState",
+    "EventBus",
     "EventManager",
+    "InMemoryEventBus",
     "PluginBaseEvent",
     "VideoProcessorDetectionEvent",
 ]

--- a/agents-core/vision_agents/core/events/__init__.py
+++ b/agents-core/vision_agents/core/events/__init__.py
@@ -7,7 +7,7 @@ from .base import (
     VideoProcessorDetectionEvent,
 )
 from .adapters import EdgeCustomEventOutboundAdapter
-from .bus import EventBus, InMemoryEventBus
+from .bus import EventBus, EventHandler, InMemoryEventBus
 from .manager import EventManager
 
 __all__ = [
@@ -17,6 +17,7 @@ __all__ = [
     "ConnectionState",
     "EdgeCustomEventOutboundAdapter",
     "EventBus",
+    "EventHandler",
     "EventManager",
     "InMemoryEventBus",
     "PluginBaseEvent",

--- a/agents-core/vision_agents/core/events/__init__.py
+++ b/agents-core/vision_agents/core/events/__init__.py
@@ -6,6 +6,7 @@ from .base import (
     PluginBaseEvent,
     VideoProcessorDetectionEvent,
 )
+from .adapters import EdgeCustomEventOutboundAdapter
 from .bus import EventBus, InMemoryEventBus
 from .manager import EventManager
 
@@ -14,6 +15,7 @@ __all__ = [
     "AudioFormat",
     "BaseEvent",
     "ConnectionState",
+    "EdgeCustomEventOutboundAdapter",
     "EventBus",
     "EventManager",
     "InMemoryEventBus",

--- a/agents-core/vision_agents/core/events/__init__.py
+++ b/agents-core/vision_agents/core/events/__init__.py
@@ -3,7 +3,6 @@ from .base import (
     AudioFormat,
     BaseEvent,
     ConnectionState,
-    InboundConnectionEvent,
     PluginBaseEvent,
     VideoProcessorDetectionEvent,
 )
@@ -20,7 +19,6 @@ __all__ = [
     "EventBus",
     "EventHandler",
     "EventManager",
-    "InboundConnectionEvent",
     "InMemoryEventBus",
     "PluginBaseEvent",
     "VideoProcessorDetectionEvent",

--- a/agents-core/vision_agents/core/events/adapters.py
+++ b/agents-core/vision_agents/core/events/adapters.py
@@ -1,0 +1,18 @@
+from dataclasses import asdict
+from typing import Any, Protocol
+
+from .base import AgentConnectionEvent
+
+
+class SupportsCustomEvent(Protocol):
+    async def send_custom_event(self, data: dict[str, Any]) -> None: ...
+
+
+class EdgeCustomEventOutboundAdapter:
+    """Bridge outbound AgentConnectionEvent messages to edge custom events."""
+
+    def __init__(self, edge: SupportsCustomEvent):
+        self._edge = edge
+
+    async def deliver(self, event: AgentConnectionEvent) -> None:
+        await self._edge.send_custom_event(asdict(event))

--- a/agents-core/vision_agents/core/events/base.py
+++ b/agents-core/vision_agents/core/events/base.py
@@ -69,6 +69,21 @@ class AgentConnectionEvent:
     version: str = "v1"
 
 
+@dataclass
+class InboundConnectionEvent:
+    type: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    correlation_id: Optional[str] = None
+    source: str = "external"
+    target: str = "agent"
+    from_participant_id: Optional[str] = None
+    to_participant_id: Optional[str] = None
+    session_id: Optional[str] = None
+    call_id: Optional[str] = None
+    version: str = "v1"
+
+
 @dataclasses.dataclass
 class ExceptionEvent:
     exc: Exception

--- a/agents-core/vision_agents/core/events/base.py
+++ b/agents-core/vision_agents/core/events/base.py
@@ -69,21 +69,6 @@ class AgentConnectionEvent:
     version: str = "v1"
 
 
-@dataclass
-class InboundConnectionEvent:
-    type: str
-    payload: dict[str, Any] = field(default_factory=dict)
-    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    correlation_id: Optional[str] = None
-    source: str = "external"
-    target: str = "agent"
-    from_participant_id: Optional[str] = None
-    to_participant_id: Optional[str] = None
-    session_id: Optional[str] = None
-    call_id: Optional[str] = None
-    version: str = "v1"
-
-
 @dataclasses.dataclass
 class ExceptionEvent:
     exc: Exception

--- a/agents-core/vision_agents/core/events/base.py
+++ b/agents-core/vision_agents/core/events/base.py
@@ -54,6 +54,21 @@ class PluginBaseEvent(BaseEvent):
     plugin_version: str | None = None
 
 
+@dataclass
+class AgentConnectionEvent:
+    type: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    correlation_id: Optional[str] = None
+    source: str = "agent"
+    target: Optional[str] = None
+    from_participant_id: Optional[str] = None
+    to_participant_id: Optional[str] = None
+    session_id: Optional[str] = None
+    call_id: Optional[str] = None
+    version: str = "v1"
+
+
 @dataclasses.dataclass
 class ExceptionEvent:
     exc: Exception

--- a/agents-core/vision_agents/core/events/bus.py
+++ b/agents-core/vision_agents/core/events/bus.py
@@ -1,10 +1,12 @@
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import Generic, Protocol, TypeVar
+from typing import Generic, Protocol, TypeAlias, TypeVar
 
 T = TypeVar("T")
-EventHandler = Callable[[T], Awaitable[None]]
+
+# Async callback signature used by EventBus subscribers.
+EventHandler: TypeAlias = Callable[[T], Awaitable[None]]
 
 
 class EventBus(Protocol[T]):

--- a/agents-core/vision_agents/core/events/bus.py
+++ b/agents-core/vision_agents/core/events/bus.py
@@ -1,0 +1,28 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+
+
+class EventBus(Protocol[T]):
+    def subscribe(self, handler: Callable[[T], Awaitable[None]]) -> None: ...
+
+    async def publish(self, event: T) -> None: ...
+
+
+class InMemoryEventBus(Generic[T]):
+    def __init__(self) -> None:
+        self._handlers: list[Callable[[T], Awaitable[None]]] = []
+
+    def subscribe(self, handler: Callable[[T], Awaitable[None]]) -> None:
+        if not asyncio.iscoroutinefunction(handler):
+            raise RuntimeError(
+                "Handlers must be coroutines. Use async def handler(event):"
+            )
+        self._handlers.append(handler)
+
+    async def publish(self, event: T) -> None:
+        if not self._handlers:
+            return
+        await asyncio.gather(*(handler(event) for handler in list(self._handlers)))

--- a/agents-core/vision_agents/core/events/bus.py
+++ b/agents-core/vision_agents/core/events/bus.py
@@ -1,22 +1,24 @@
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from typing import Generic, Protocol, TypeVar
 
 T = TypeVar("T")
+EventHandler = Callable[[T], Awaitable[None]]
 
 
 class EventBus(Protocol[T]):
-    def subscribe(self, handler: Callable[[T], Awaitable[None]]) -> None: ...
+    def subscribe(self, handler: EventHandler[T]) -> None: ...
 
     async def publish(self, event: T) -> None: ...
 
 
 class InMemoryEventBus(Generic[T]):
     def __init__(self) -> None:
-        self._handlers: list[Callable[[T], Awaitable[None]]] = []
+        self._handlers: list[EventHandler[T]] = []
 
-    def subscribe(self, handler: Callable[[T], Awaitable[None]]) -> None:
-        if not asyncio.iscoroutinefunction(handler):
+    def subscribe(self, handler: EventHandler[T]) -> None:
+        if not inspect.iscoroutinefunction(handler):
             raise RuntimeError(
                 "Handlers must be coroutines. Use async def handler(event):"
             )

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -10,7 +10,11 @@ from vision_agents.core import Agent, User
 from vision_agents.core.agents.conversation import InMemoryConversation
 from vision_agents.core.edge import Call, EdgeTransport
 from vision_agents.core.edge.types import Participant
-from vision_agents.core.events import AgentConnectionEvent, EventManager
+from vision_agents.core.events import (
+    AgentConnectionEvent,
+    EdgeCustomEventOutboundAdapter,
+    EventManager,
+)
 from vision_agents.core.llm.events import (
     RealtimeAgentSpeechTranscriptionEvent,
     RealtimeAudioOutputEvent,
@@ -289,6 +293,69 @@ class TestAgent:
         await agent.send_event(outbound_event)
 
         assert adapter.received == [outbound_event]
+
+    async def test_send_event_delivers_to_edge_custom_events(self, call: Call):
+        edge = DummyEdge()
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=edge,
+            agent_user=User(id="agent-1", name="test"),
+        )
+        outbound_event = AgentConnectionEvent(
+            type="agent.turn_ended",
+            payload={"turn_id": "turn-123"},
+            target="avatar",
+            call_id=call.id,
+        )
+
+        async with agent.join(call):
+            await agent.send_event(outbound_event)
+
+        assert edge.last_custom_event["type"] == "agent.turn_ended"
+        assert edge.last_custom_event["payload"] == {"turn_id": "turn-123"}
+        assert edge.last_custom_event["target"] == "avatar"
+        assert edge.last_custom_event["call_id"] == call.id
+        assert edge.last_custom_event["event_id"] == outbound_event.event_id
+        assert edge.last_custom_event["version"] == "v1"
+
+    async def test_send_event_can_disable_default_edge_adapter(self, call: Call):
+        edge = DummyEdge()
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=edge,
+            agent_user=User(id="agent-1", name="test"),
+            auto_register_edge_outbound_adapter=False,
+        )
+        outbound_event = AgentConnectionEvent(
+            type="agent.turn_ended",
+            payload={"turn_id": "turn-123"},
+            target="avatar",
+            call_id=call.id,
+        )
+
+        async with agent.join(call):
+            await agent.send_event(outbound_event)
+
+        assert not hasattr(edge, "last_custom_event")
+
+    async def test_edge_outbound_adapter_serializes_event_dataclass(self):
+        edge = DummyEdge()
+        adapter = EdgeCustomEventOutboundAdapter(edge=edge)
+        event = AgentConnectionEvent(
+            type="agent.turn_ended",
+            payload={"turn_id": "turn-123"},
+            target="avatar",
+        )
+
+        await adapter.deliver(event)
+
+        assert edge.last_custom_event["type"] == "agent.turn_ended"
+        assert edge.last_custom_event["payload"] == {"turn_id": "turn-123"}
+        assert edge.last_custom_event["target"] == "avatar"
+        assert edge.last_custom_event["event_id"] == event.event_id
+        assert edge.last_custom_event["source"] == "agent"
 
     async def test_send_metrics_event(self):
         """Test that metrics are sent as custom events."""

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -14,6 +14,7 @@ from vision_agents.core.events import (
     AgentConnectionEvent,
     EdgeCustomEventOutboundAdapter,
     EventManager,
+    InboundConnectionEvent,
 )
 from vision_agents.core.llm.events import (
     RealtimeAgentSpeechTranscriptionEvent,
@@ -339,6 +340,54 @@ class TestAgent:
             await agent.send_event(outbound_event)
 
         assert not hasattr(edge, "last_custom_event")
+
+    async def test_receive_event_publishes_to_inbound_bus(self):
+        edge = DummyEdge()
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=edge,
+            agent_user=User(id="agent-1", name="test"),
+        )
+        received_events: list[InboundConnectionEvent] = []
+
+        async def on_inbound(event: InboundConnectionEvent) -> None:
+            received_events.append(event)
+
+        agent.inbound_events.subscribe(on_inbound)
+        inbound_event = InboundConnectionEvent(
+            type="ui.button.clicked",
+            payload={"id": "confirm"},
+            source="frontend",
+        )
+        result = await agent.receive_event(inbound_event)
+
+        assert result is None
+        assert received_events == [inbound_event]
+
+    async def test_register_inbound_handler_receives_inbound_event(self):
+        edge = DummyEdge()
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=edge,
+            agent_user=User(id="agent-1", name="test"),
+        )
+        received_events: list[InboundConnectionEvent] = []
+
+        async def on_inbound(event: InboundConnectionEvent) -> None:
+            received_events.append(event)
+
+        agent.register_inbound_handler(on_inbound)
+        inbound_event = InboundConnectionEvent(
+            type="ui.modal.submit",
+            payload={"value": "yes"},
+            source="frontend",
+        )
+
+        await agent.receive_event(inbound_event)
+
+        assert received_events == [inbound_event]
 
     async def test_edge_outbound_adapter_serializes_event_dataclass(self):
         edge = DummyEdge()

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -14,7 +14,6 @@ from vision_agents.core.events import (
     AgentConnectionEvent,
     EdgeCustomEventOutboundAdapter,
     EventManager,
-    InboundConnectionEvent,
 )
 from vision_agents.core.llm.events import (
     RealtimeAgentSpeechTranscriptionEvent,
@@ -340,54 +339,6 @@ class TestAgent:
             await agent.send_event(outbound_event)
 
         assert not hasattr(edge, "last_custom_event")
-
-    async def test_receive_event_publishes_to_inbound_bus(self):
-        edge = DummyEdge()
-        agent = Agent(
-            llm=DummyLLM(),
-            tts=DummyTTS(),
-            edge=edge,
-            agent_user=User(id="agent-1", name="test"),
-        )
-        received_events: list[InboundConnectionEvent] = []
-
-        async def on_inbound(event: InboundConnectionEvent) -> None:
-            received_events.append(event)
-
-        agent.inbound_events.subscribe(on_inbound)
-        inbound_event = InboundConnectionEvent(
-            type="ui.button.clicked",
-            payload={"id": "confirm"},
-            source="frontend",
-        )
-        result = await agent.receive_event(inbound_event)
-
-        assert result is None
-        assert received_events == [inbound_event]
-
-    async def test_register_inbound_handler_receives_inbound_event(self):
-        edge = DummyEdge()
-        agent = Agent(
-            llm=DummyLLM(),
-            tts=DummyTTS(),
-            edge=edge,
-            agent_user=User(id="agent-1", name="test"),
-        )
-        received_events: list[InboundConnectionEvent] = []
-
-        async def on_inbound(event: InboundConnectionEvent) -> None:
-            received_events.append(event)
-
-        agent.register_inbound_handler(on_inbound)
-        inbound_event = InboundConnectionEvent(
-            type="ui.modal.submit",
-            payload={"value": "yes"},
-            source="frontend",
-        )
-
-        await agent.receive_event(inbound_event)
-
-        assert received_events == [inbound_event]
 
     async def test_edge_outbound_adapter_serializes_event_dataclass(self):
         edge = DummyEdge()

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -10,7 +10,7 @@ from vision_agents.core import Agent, User
 from vision_agents.core.agents.conversation import InMemoryConversation
 from vision_agents.core.edge import Call, EdgeTransport
 from vision_agents.core.edge.types import Participant
-from vision_agents.core.events import EventManager
+from vision_agents.core.events import AgentConnectionEvent, EventManager
 from vision_agents.core.llm.events import (
     RealtimeAgentSpeechTranscriptionEvent,
     RealtimeAudioOutputEvent,
@@ -168,6 +168,14 @@ class RecordingEdge(DummyEdge):
         return self.recorded_audio_track
 
 
+class DummyOutboundAdapter:
+    def __init__(self):
+        self.received: list[AgentConnectionEvent] = []
+
+    async def deliver(self, event: AgentConnectionEvent) -> None:
+        self.received.append(event)
+
+
 class TestAgent:
     @pytest.mark.parametrize(
         "edge_params",
@@ -234,6 +242,53 @@ class TestAgent:
         await agent.send_custom_event(test_data)
 
         assert edge.last_custom_event == test_data
+
+    async def test_send_event_publishes_to_outbound_bus(self):
+        edge = DummyEdge()
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=edge,
+            agent_user=User(id="agent-1", name="test"),
+        )
+
+        received_events: list[AgentConnectionEvent] = []
+
+        async def on_event(event: AgentConnectionEvent) -> None:
+            received_events.append(event)
+
+        agent.outbound_events.subscribe(on_event)
+
+        outbound_event = AgentConnectionEvent(
+            type="agent.turn_ended",
+            payload={"turn_id": "turn-1"},
+            target="avatar",
+        )
+        result = await agent.send_event(outbound_event)
+
+        assert result is None
+        assert received_events == [outbound_event]
+
+    async def test_send_event_delivers_to_registered_outbound_adapter(self):
+        edge = DummyEdge()
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=edge,
+            agent_user=User(id="agent-1", name="test"),
+        )
+        adapter = DummyOutboundAdapter()
+        agent.register_outbound_adapter(adapter)
+
+        outbound_event = AgentConnectionEvent(
+            type="ui.button.set_enabled",
+            payload={"id": "confirm", "enabled": True},
+            target="frontend",
+        )
+
+        await agent.send_event(outbound_event)
+
+        assert adapter.received == [outbound_event]
 
     async def test_send_metrics_event(self):
         """Test that metrics are sent as custom events."""


### PR DESCRIPTION
## Why
We need a general outbound event architecture for Agent-to-external communication that stays transport-agnostic and provider-independent.

This creates a stable boundary for FE/BE event flows and future transport adapters without coupling core agent APIs to vendor-specific transport semantics.

## Changes
- add an agent-facing outbound event contract and bus path (AgentConnectionEvent, EventBus, Agent.send_event)
- add adapter registration for outbound delivery while keeping transport concerns outside the bus contract
- add a default edge bridge adapter that forwards outbound events through custom events after join()
- add an opt-out switch for deployments that want full adapter control
- add tests for outbound publish path, adapter delivery, edge delivery, and opt-out behavior
