### PR TITLE
Fix Sarvam STT ordering 

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -243,6 +243,26 @@ class StreamEdge(EdgeTransport[StreamCall]):
             )
             return
 
+        # User reconnected with a new session — the WebRTC media track is reused
+        # so track_added won't fire again. Migrate the stale session entry.
+        for old_key, old_info in list(self._track_map.items()):
+            old_user, old_session, old_type = old_key
+            if old_user == user_id and old_type == track_type_int and old_session != session_id:
+                del self._track_map[old_key]
+                self._track_map[track_key] = {"track_id": old_info["track_id"], "published": True}
+                logger.info(
+                    f"Migrated track for {user_id} from session {old_session} to {session_id}"
+                )
+                self.events.send(
+                    events.TrackAddedEvent(
+                        plugin_name="getstream",
+                        track_id=old_info["track_id"],
+                        track_type=track_type,
+                        participant=_to_core_participant(event.participant),
+                    )
+                )
+                return
+
         # Wait for pending track to be populated (with 10 second timeout)
         # SFU might send TrackPublishedEvent before WebRTC processes track_added
         track_id = None

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -247,9 +247,16 @@ class StreamEdge(EdgeTransport[StreamCall]):
         # so track_added won't fire again. Migrate the stale session entry.
         for old_key, old_info in list(self._track_map.items()):
             old_user, old_session, old_type = old_key
-            if old_user == user_id and old_type == track_type_int and old_session != session_id:
+            if (
+                old_user == user_id
+                and old_type == track_type_int
+                and old_session != session_id
+            ):
                 del self._track_map[old_key]
-                self._track_map[track_key] = {"track_id": old_info["track_id"], "published": True}
+                self._track_map[track_key] = {
+                    "track_id": old_info["track_id"],
+                    "published": True,
+                }
                 logger.info(
                     f"Migrated track for {user_id} from session {old_session} to {session_id}"
                 )

--- a/plugins/sarvam/example/sarvam_example.py
+++ b/plugins/sarvam/example/sarvam_example.py
@@ -35,8 +35,8 @@ async def create_agent(**kwargs) -> Agent:
             "Reply in the same language the user speaks. "
             "Keep replies short and conversational."
         ),
-        stt=sarvam.STT(language="hi-IN"),
-        tts=sarvam.TTS(language="hi-IN", speaker="shubh"),
+        stt=sarvam.STT(language="en-IN"),
+        tts=sarvam.TTS(language="en-IN", speaker="shubh"),
         llm=sarvam.LLM(model="sarvam-m"),
     )
     return agent

--- a/plugins/sarvam/tests/test_sarvam_stt.py
+++ b/plugins/sarvam/tests/test_sarvam_stt.py
@@ -63,6 +63,25 @@ class TestSarvamSTT:
         url = stt._build_ws_url()
         assert "language-code" not in url
 
+    async def test_build_ws_url_translate_endpoint_for_saaras_v25(self):
+        stt = STT(api_key="sk_test", model="saaras:v2.5")
+        url = stt._build_ws_url()
+        assert url.startswith("wss://api.sarvam.ai/speech-to-text-translate/ws?")
+
+    async def test_build_ws_url_regular_endpoint_for_saarika(self):
+        stt = STT(api_key="sk_test", model="saarika:v2.5")
+        url = stt._build_ws_url()
+        assert url.startswith("wss://api.sarvam.ai/speech-to-text/ws?")
+
+    async def test_mode_only_included_for_supporting_models(self):
+        stt = STT(api_key="sk_test", model="saarika:v2.5", mode="transcribe")
+        url = stt._build_ws_url()
+        assert "mode=" not in url
+
+        stt_v3 = STT(api_key="sk_test", model="saaras:v3", mode="translate")
+        url_v3 = stt_v3._build_ws_url()
+        assert "mode=translate" in url_v3
+
     async def test_process_audio_uses_pcm_s16le_codec(self):
         class FakeWebSocket:
             def __init__(self) -> None:
@@ -87,9 +106,8 @@ class TestSarvamSTT:
         await stt.process_audio(pcm_data, participant=participant)
 
         message = json.loads(ws.sent_messages[0])
-        assert message["audio"]["input_audio_codec"] == "pcm_s16le"
+        assert message["audio"]["encoding"] == "audio/wav"
         assert message["audio"]["sample_rate"] == 16000
-        assert "encoding" not in message["audio"]
 
 
 @pytest.mark.skipif(not os.getenv("SARVAM_API_KEY"), reason="SARVAM_API_KEY not set")

--- a/plugins/sarvam/tests/test_sarvam_tts.py
+++ b/plugins/sarvam/tests/test_sarvam_tts.py
@@ -22,7 +22,7 @@ class TestSarvamTTS:
         tts = TTS(api_key="sk_test")
         assert tts.model == "bulbul:v3"
         assert tts.language == "hi-IN"
-        assert tts.speaker == "anushka"
+        assert tts.speaker == "shubh"
         assert tts.sample_rate == 24000
         assert tts.provider_name == "sarvam"
 
@@ -31,9 +31,21 @@ class TestSarvamTTS:
             TTS(api_key="sk_test", model="not-a-model")
 
     async def test_custom_speaker_and_language(self):
-        tts = TTS(api_key="sk_test", language="en-IN", speaker="anushka")
+        tts = TTS(api_key="sk_test", language="en-IN", speaker="ritu")
         assert tts.language == "en-IN"
-        assert tts.speaker == "anushka"
+        assert tts.speaker == "ritu"
+
+    async def test_v3_beta_model_accepted(self):
+        tts = TTS(api_key="sk_test", model="bulbul:v3-beta", speaker="shubh")
+        assert tts.model == "bulbul:v3-beta"
+
+    async def test_incompatible_speaker_rejected(self):
+        with pytest.raises(ValueError, match="not compatible"):
+            TTS(api_key="sk_test", model="bulbul:v2", speaker="shubh")
+
+    async def test_v3_speaker_on_v2_rejected(self):
+        with pytest.raises(ValueError, match="not compatible"):
+            TTS(api_key="sk_test", model="bulbul:v3", speaker="hitesh")
 
 
 @pytest.mark.skipif(not os.getenv("SARVAM_API_KEY"), reason="SARVAM_API_KEY not set")
@@ -43,7 +55,7 @@ class TestSarvamTTSIntegration:
 
     @pytest.fixture
     async def tts(self):
-        t = TTS(language="en-IN", speaker="anand")
+        t = TTS(language="en-IN", speaker="shubh")
         try:
             yield t
         finally:

--- a/plugins/sarvam/vision_agents/plugins/sarvam/__init__.py
+++ b/plugins/sarvam/vision_agents/plugins/sarvam/__init__.py
@@ -1,5 +1,5 @@
 from .llm import SarvamLLM as LLM
 from .stt import STT
-from .tts import TTS
+from .tts import TTS, SarvamTTSError
 
-__all__ = ["LLM", "STT", "TTS"]
+__all__ = ["LLM", "STT", "TTS", "SarvamTTSError"]

--- a/plugins/sarvam/vision_agents/plugins/sarvam/stt.py
+++ b/plugins/sarvam/vision_agents/plugins/sarvam/stt.py
@@ -25,11 +25,16 @@ from vision_agents.core.stt import TranscriptResponse
 
 logger = logging.getLogger(__name__)
 
-WS_BASE_URL = "wss://api.sarvam.ai/speech-to-text/ws"
+WS_STT_URL = "wss://api.sarvam.ai/speech-to-text/ws"
+WS_STT_TRANSLATE_URL = "wss://api.sarvam.ai/speech-to-text-translate/ws"
 
 SUPPORTED_SAMPLE_RATES = {8000, 16000}
-SUPPORTED_MODELS = {"saaras:v3", "saarika:v2.5", "saaras:v2.5"}
 SUPPORTED_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
+
+MODELS_USING_TRANSLATE_ENDPOINT = {"saaras:v2.5"}
+MODELS_SUPPORTING_PROMPT = {"saaras:v2.5", "saaras:v3"}
+MODELS_SUPPORTING_MODE = {"saaras:v3"}
+SUPPORTED_MODELS = {"saaras:v3", "saarika:v2.5", "saaras:v2.5"}
 
 
 class STT(stt.STT):
@@ -109,7 +114,17 @@ class STT(stt.STT):
         self._current_participant: Optional[Participant] = None
         self._audio_start_time: Optional[float] = None
 
+        self._in_speech: bool = False
+        self._pending_transcript: Optional[str] = None
+        self._pending_response: Optional[TranscriptResponse] = None
+        self._turn_end_pending: bool = False
+
     def _build_ws_url(self) -> str:
+        base = (
+            WS_STT_TRANSLATE_URL
+            if self.model in MODELS_USING_TRANSLATE_ENDPOINT
+            else WS_STT_URL
+        )
         params: dict[str, str | int] = {
             "model": self.model,
             "sample_rate": self.sample_rate,
@@ -117,11 +132,11 @@ class STT(stt.STT):
         }
         if self.language is not None:
             params["language-code"] = self.language
-        if self.mode is not None:
+        if self.mode is not None and self.model in MODELS_SUPPORTING_MODE:
             params["mode"] = self.mode
         if self.high_vad_sensitivity:
             params["high_vad_sensitivity"] = "true"
-        return f"{WS_BASE_URL}?{urlencode(params)}"
+        return f"{base}?{urlencode(params)}"
 
     async def start(self) -> None:
         """Open the Sarvam WebSocket and start the receive loop."""
@@ -133,8 +148,10 @@ class STT(stt.STT):
         self._session = aiohttp.ClientSession()
         self._ws = await self._session.ws_connect(url, headers=headers)
 
-        if self._prompt:
-            await self._ws.send_str(json.dumps({"config": {"prompt": self._prompt}}))
+        if self._prompt and self.model in MODELS_SUPPORTING_PROMPT:
+            await self._ws.send_str(
+                json.dumps({"type": "config", "prompt": self._prompt})
+            )
 
         self._receive_task = asyncio.create_task(self._receive_loop())
         self._connection_ready.set()
@@ -142,7 +159,7 @@ class STT(stt.STT):
     async def process_audio(
         self,
         pcm_data: PcmData,
-        participant: Optional[Participant] = None,
+        participant: Participant,
     ) -> None:
         """Send a PCM audio chunk to Sarvam.
 
@@ -169,7 +186,7 @@ class STT(stt.STT):
         message = {
             "audio": {
                 "data": base64.b64encode(audio_bytes).decode("ascii"),
-                "input_audio_codec": "pcm_s16le",
+                "encoding": "audio/wav",
                 "sample_rate": self.sample_rate,
             }
         }
@@ -216,7 +233,9 @@ class STT(stt.STT):
         - ``{"type": "events", "data": {"signal_type": "START_SPEECH" | "END_SPEECH"}}``
           VAD boundaries used to drive turn events.
         - ``{"type": "data", "data": {"transcript": "...", "language_code": ...}}``
-          The finalized transcript for the current utterance (no partials).
+          Transcript updates during an utterance. Sarvam may send multiple
+          ``data`` messages per utterance as it refines the text. Only the
+          last one before ``END_SPEECH`` is treated as final.
         - ``{"type": "error", ...}`` or any message with an ``error`` key.
         """
         msg_type = data.get("type", "")
@@ -228,10 +247,25 @@ class STT(stt.STT):
             if participant is None:
                 return
             if signal == "START_SPEECH":
+                self._in_speech = True
+                self._pending_transcript = None
+                self._pending_response = None
+                self._turn_end_pending = False
                 self._emit_turn_started_event(participant)
             elif signal == "END_SPEECH":
+                self._in_speech = False
                 self._audio_start_time = None
-                self._emit_turn_ended_event(participant)
+                if self._pending_transcript and self._pending_response:
+                    self._emit_transcript_event(
+                        self._pending_transcript,
+                        participant,
+                        self._pending_response,
+                    )
+                    self._pending_transcript = None
+                    self._pending_response = None
+                    self._emit_turn_ended_event(participant)
+                else:
+                    self._turn_end_pending = True
             return
 
         if msg_type == "error" or "error" in data:
@@ -274,9 +308,16 @@ class STT(stt.STT):
             audio_duration_ms=audio_duration_ms,
         )
 
-        # Sarvam streaming only sends finalized transcripts (per utterance),
-        # so treat every `type: data` message as a final transcript event.
-        self._emit_transcript_event(transcript_text, participant, response)
+        if self._in_speech:
+            self._pending_transcript = transcript_text
+            self._pending_response = response
+            self._emit_partial_transcript_event(transcript_text, participant, response)
+        elif self._turn_end_pending:
+            self._turn_end_pending = False
+            self._emit_transcript_event(transcript_text, participant, response)
+            self._emit_turn_ended_event(participant)
+        else:
+            self._emit_transcript_event(transcript_text, participant, response)
 
     async def close(self) -> None:
         """Send end_of_stream, close the WebSocket, and clean up."""

--- a/plugins/sarvam/vision_agents/plugins/sarvam/tts.py
+++ b/plugins/sarvam/vision_agents/plugins/sarvam/tts.py
@@ -28,20 +28,67 @@ KEEPALIVE_INTERVAL_S = 20
 
 MODEL_SPEAKER_COMPATIBILITY: dict[str, set[str]] = {
     "bulbul:v2": {
-        "anushka", "manisha", "vidya", "arya",
-        "abhilash", "karun", "hitesh",
+        "anushka",
+        "manisha",
+        "vidya",
+        "arya",
+        "abhilash",
+        "karun",
+        "hitesh",
     },
     "bulbul:v3-beta": {
-        "shubh", "ritu", "rahul", "pooja", "simran", "kavya", "amit",
-        "ratan", "rohan", "dev", "ishita", "shreya", "manan", "sumit",
-        "priya", "aditya", "kabir", "neha", "varun", "roopa", "aayan",
-        "ashutosh", "advait", "amelia", "sophia",
+        "shubh",
+        "ritu",
+        "rahul",
+        "pooja",
+        "simran",
+        "kavya",
+        "amit",
+        "ratan",
+        "rohan",
+        "dev",
+        "ishita",
+        "shreya",
+        "manan",
+        "sumit",
+        "priya",
+        "aditya",
+        "kabir",
+        "neha",
+        "varun",
+        "roopa",
+        "aayan",
+        "ashutosh",
+        "advait",
+        "amelia",
+        "sophia",
     },
     "bulbul:v3": {
-        "shubh", "ritu", "rahul", "pooja", "simran", "kavya", "amit",
-        "ratan", "rohan", "dev", "ishita", "shreya", "manan", "sumit",
-        "priya", "aditya", "kabir", "neha", "varun", "roopa", "aayan",
-        "ashutosh", "advait", "amelia", "sophia",
+        "shubh",
+        "ritu",
+        "rahul",
+        "pooja",
+        "simran",
+        "kavya",
+        "amit",
+        "ratan",
+        "rohan",
+        "dev",
+        "ishita",
+        "shreya",
+        "manan",
+        "sumit",
+        "priya",
+        "aditya",
+        "kabir",
+        "neha",
+        "varun",
+        "roopa",
+        "aayan",
+        "ashutosh",
+        "advait",
+        "amelia",
+        "sophia",
     },
 }
 
@@ -288,8 +335,6 @@ class TTS(tts.TTS):
             elif msg_type == "error":
                 error_data = data.get("data") or {}
                 error_msg = (
-                    error_data.get("message")
-                    or data.get("error")
-                    or "Sarvam TTS error"
+                    error_data.get("message") or data.get("error") or "Sarvam TTS error"
                 )
                 raise SarvamTTSError(str(error_msg))

--- a/plugins/sarvam/vision_agents/plugins/sarvam/tts.py
+++ b/plugins/sarvam/vision_agents/plugins/sarvam/tts.py
@@ -22,7 +22,36 @@ logger = logging.getLogger(__name__)
 
 WS_BASE_URL = "wss://api.sarvam.ai/text-to-speech/ws"
 
-SUPPORTED_MODELS = {"bulbul:v2", "bulbul:v3"}
+SUPPORTED_MODELS = {"bulbul:v2", "bulbul:v3-beta", "bulbul:v3"}
+
+KEEPALIVE_INTERVAL_S = 20
+
+MODEL_SPEAKER_COMPATIBILITY: dict[str, set[str]] = {
+    "bulbul:v2": {
+        "anushka", "manisha", "vidya", "arya",
+        "abhilash", "karun", "hitesh",
+    },
+    "bulbul:v3-beta": {
+        "shubh", "ritu", "rahul", "pooja", "simran", "kavya", "amit",
+        "ratan", "rohan", "dev", "ishita", "shreya", "manan", "sumit",
+        "priya", "aditya", "kabir", "neha", "varun", "roopa", "aayan",
+        "ashutosh", "advait", "amelia", "sophia",
+    },
+    "bulbul:v3": {
+        "shubh", "ritu", "rahul", "pooja", "simran", "kavya", "amit",
+        "ratan", "rohan", "dev", "ishita", "shreya", "manan", "sumit",
+        "priya", "aditya", "kabir", "neha", "varun", "roopa", "aayan",
+        "ashutosh", "advait", "amelia", "sophia",
+    },
+}
+
+MODELS_SUPPORTING_PITCH = {"bulbul:v2"}
+MODELS_SUPPORTING_LOUDNESS = {"bulbul:v2"}
+MODELS_SUPPORTING_TEMPERATURE = {"bulbul:v3-beta", "bulbul:v3"}
+
+
+class SarvamTTSError(Exception):
+    """Raised when Sarvam TTS returns an error message over WebSocket."""
 
 
 class TTS(tts.TTS):
@@ -37,14 +66,14 @@ class TTS(tts.TTS):
         api_key: Optional[str] = None,
         model: str = "bulbul:v3",
         language: str = "hi-IN",
-        speaker: str = "anushka",
+        speaker: str = "shubh",
         sample_rate: int = 24000,
         pace: Optional[float] = None,
         pitch: Optional[float] = None,
         loudness: Optional[float] = None,
         temperature: Optional[float] = None,
         enable_preprocessing: bool = True,
-        idle_timeout: float = 1.5,
+        idle_timeout: float = 5.0,
     ) -> None:
         """Initialize Sarvam TTS.
 
@@ -55,14 +84,15 @@ class TTS(tts.TTS):
             speaker: Speaker voice id (e.g. ``shubh``, ``anushka``).
             sample_rate: Output sample rate in Hz. Defaults to 24000.
             pace: Speech pace. Range depends on model
-                (bulbul:v3 supports 0.5–2.0).
+                (bulbul:v3 supports 0.5-2.0).
             pitch: Speech pitch. Only supported on bulbul:v2.
             loudness: Speech loudness. Only supported on bulbul:v2.
-            temperature: Sampling temperature. Only supported on bulbul:v3.
+            temperature: Sampling temperature. Only supported on
+                bulbul:v3 / bulbul:v3-beta.
             enable_preprocessing: Normalize mixed-language / numeric text.
-            idle_timeout: Seconds of silence from the server before we treat
-                a synthesis as complete. Sarvam does not always emit an
-                explicit completion event, so this bounds ``stream_audio``.
+            idle_timeout: Fallback seconds of server silence before treating
+                synthesis as complete. Normally the server sends an explicit
+                completion event; this is a safety net.
         """
         super().__init__(provider_name="sarvam")
 
@@ -76,6 +106,13 @@ class TTS(tts.TTS):
         if not self._api_key:
             raise ValueError(
                 "SARVAM_API_KEY env var or api_key parameter required for Sarvam TTS"
+            )
+
+        compatible = MODEL_SPEAKER_COMPATIBILITY.get(model)
+        if compatible is not None and speaker not in compatible:
+            raise ValueError(
+                f"Speaker '{speaker}' is not compatible with model '{model}'. "
+                f"Compatible speakers: {sorted(compatible)}"
             )
 
         self.model = model
@@ -93,6 +130,7 @@ class TTS(tts.TTS):
         self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
         self._lock = asyncio.Lock()
         self._stop_event = asyncio.Event()
+        self._keepalive_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
         """Open the persistent WebSocket connection."""
@@ -131,7 +169,6 @@ class TTS(tts.TTS):
                 await self._ws.send_str(json.dumps({"type": "cancel"}))
             except (aiohttp.ClientError, ConnectionError):
                 pass
-        # Easiest way to flush the server-side queue is a reconnect.
         await self._reset_connection()
 
     async def _ensure_connection(self) -> aiohttp.ClientWebSocketResponse:
@@ -141,11 +178,12 @@ class TTS(tts.TTS):
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
 
-        url = f"{WS_BASE_URL}?model={self.model}"
+        url = f"{WS_BASE_URL}?model={self.model}&send_completion_event=true"
         headers = {"api-subscription-key": self._api_key or ""}
         ws = await self._session.ws_connect(url, headers=headers)
 
         config: dict[str, Any] = {
+            "model": self.model,
             "target_language_code": self.language,
             "speaker": self.speaker,
             "speech_sample_rate": self.sample_rate,
@@ -154,19 +192,42 @@ class TTS(tts.TTS):
         }
         if self.pace is not None:
             config["pace"] = self.pace
-        if self.pitch is not None:
+        if self.pitch is not None and self.model in MODELS_SUPPORTING_PITCH:
             config["pitch"] = self.pitch
-        if self.loudness is not None:
+        if self.loudness is not None and self.model in MODELS_SUPPORTING_LOUDNESS:
             config["loudness"] = self.loudness
-        if self.temperature is not None:
+        if self.temperature is not None and self.model in MODELS_SUPPORTING_TEMPERATURE:
             config["temperature"] = self.temperature
 
         await ws.send_str(json.dumps({"type": "config", "data": config}))
         self._ws = ws
+        self._start_keepalive()
         logger.debug("Sarvam TTS websocket connected at %dHz", self.sample_rate)
         return ws
 
+    def _start_keepalive(self) -> None:
+        self._stop_keepalive()
+        self._keepalive_task = asyncio.create_task(self._keepalive_loop())
+
+    def _stop_keepalive(self) -> None:
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            self._keepalive_task = None
+
+    async def _keepalive_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(KEEPALIVE_INTERVAL_S)
+                if self._ws is not None and not self._ws.closed:
+                    await self._ws.send_str(json.dumps({"type": "ping"}))
+        except asyncio.CancelledError:
+            pass
+        except (aiohttp.ClientError, ConnectionError):
+            logger.debug("Sarvam TTS keepalive send failed")
+
     async def _reset_connection(self) -> None:
+        self._stop_keepalive()
+
         if self._ws is not None and not self._ws.closed:
             try:
                 await self._ws.close()
@@ -181,12 +242,7 @@ class TTS(tts.TTS):
     async def _receive_audio(
         self, ws: aiohttp.ClientWebSocketResponse
     ) -> AsyncIterator[PcmData]:
-        """Yield PcmData chunks until flushed, cancelled, idle, or disconnected.
-
-        Sarvam does not always send an explicit completion event after the
-        final audio chunk, so we also treat a short idle gap (no message
-        within ``self._idle_timeout`` seconds) as end-of-stream.
-        """
+        """Yield PcmData chunks until completion event, cancel, idle, or disconnect."""
         while True:
             if self._stop_event.is_set():
                 break
@@ -223,8 +279,17 @@ class TTS(tts.TTS):
                     channels=1,
                     format=AudioFormat.S16,
                 )
+            elif msg_type == "event":
+                event_data = data.get("data") or {}
+                if event_data.get("event_type") == "final":
+                    break
             elif msg_type in ("flushed", "complete", "done"):
                 break
             elif msg_type == "error":
-                logger.error("Sarvam TTS error: %s", data)
-                break
+                error_data = data.get("data") or {}
+                error_msg = (
+                    error_data.get("message")
+                    or data.get("error")
+                    or "Sarvam TTS error"
+                )
+                raise SarvamTTSError(str(error_msg))


### PR DESCRIPTION
- Implement session migration for WebRTC media tracks in StreamEdge, ensuring seamless user reconnections.
- Update Sarvam STT to support new WebSocket URL structures for translation and regular endpoints.
- Modify TTS to include speaker compatibility checks and improve keepalive functionality for WebSocket connections.
- Adjust default speaker settings in TTS and update related tests for consistency.
- Add new unit tests for STT to validate WebSocket URL generation and model compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sarvam TTS: Added support for bulbul:v3-beta model and speaker-model compatibility validation
  * Sarvam TTS: Added WebSocket keepalive support
  * SarvamTTSError now publicly exported

* **Bug Fixes**
  * Sarvam STT: Updated audio encoding to WAV format
  * Sarvam TTS: Improved error handling with dedicated exception type
  * GetStream: Enhanced session migration handling for stale tracks

* **Changes**
  * Sarvam TTS: Default speaker changed to "shubh"; idle timeout increased to 5.0s
  * Sarvam example: Updated to English language configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->