### PR TITLE
Fix Gemini Realtime infinite error loop on network disconnection

### DIFF
--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -2,7 +2,9 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import websockets
 from dotenv import load_dotenv
+from google.genai.errors import APIError
 from getstream.video.rtc import AudioFormat, PcmData
 from google.genai.types import (
     Blob,
@@ -15,11 +17,13 @@ from google.genai.types import (
     Part,
     Transcription,
 )
+from websockets.frames import Close
 from vision_agents.core.llm.events import (
     LLMResponseChunkEvent,
     RealtimeAgentSpeechTranscriptionEvent,
     RealtimeAudioOutputDoneEvent,
     RealtimeAudioOutputEvent,
+    RealtimeDisconnectedEvent,
     RealtimeUserSpeechTranscriptionEvent,
 )
 from vision_agents.core.tts.manual_test import play_pcm_with_ffplay
@@ -486,3 +490,125 @@ class TestGeminiRealtimeProcessEvents:
             assert finished is False
         finally:
             await rt.close()
+
+
+class TestGeminiRealtimeProcessingLoop:
+    async def test_clean_websocket_close_emits_disconnected(self):
+        rt = _make_realtime()
+
+        async def _raise_closed_ok():
+            raise websockets.ConnectionClosedOK(Close(1000, "normal"), None)
+
+        rt._process_events = _raise_closed_ok
+
+        emitted: list[object] = []
+        rt.events.send = lambda e: emitted.append(e)
+
+        await rt._processing_loop()
+
+        assert len(emitted) == 1
+        assert isinstance(emitted[0], RealtimeDisconnectedEvent)
+        assert emitted[0].was_clean is True
+
+    async def test_non_reconnectable_close_emits_disconnected(self):
+        rt = _make_realtime()
+
+        async def _raise_closed_error():
+            raise websockets.ConnectionClosedError(Close(1006, "abnormal"), None)
+
+        rt._process_events = _raise_closed_error
+
+        emitted: list[object] = []
+        rt.events.send = lambda e: emitted.append(e)
+
+        await rt._processing_loop()
+
+        assert len(emitted) == 1
+        assert isinstance(emitted[0], RealtimeDisconnectedEvent)
+        assert emitted[0].was_clean is False
+        assert "1006" in emitted[0].reason
+
+    async def test_reconnectable_close_triggers_reconnect(self):
+        rt = _make_realtime()
+        reconnected = asyncio.Event()
+
+        async def _raise_reconnectable():
+            if not reconnected.is_set():
+                reconnected.set()
+                raise websockets.ConnectionClosedError(Close(1011, "timeout"), None)
+            await asyncio.sleep(10)
+
+        rt._process_events = _raise_reconnectable
+        rt.connect = AsyncMock()
+
+        emitted: list[object] = []
+        rt.events.send = lambda e: emitted.append(e)
+
+        task = asyncio.create_task(rt._processing_loop())
+        await asyncio.wait_for(reconnected.wait(), timeout=2.0)
+        task.cancel()
+        await task
+
+        rt.connect.assert_called_once()
+        disconnected = [e for e in emitted if isinstance(e, RealtimeDisconnectedEvent)]
+        assert len(disconnected) == 0
+
+    async def test_consecutive_errors_stop_loop(self):
+        rt = _make_realtime()
+
+        async def _always_fail():
+            raise ConnectionError("network down")
+
+        rt._process_events = _always_fail
+
+        emitted: list[object] = []
+        rt.events.send = lambda e: emitted.append(e)
+
+        await rt._processing_loop()
+
+        disconnected = [e for e in emitted if isinstance(e, RealtimeDisconnectedEvent)]
+        assert len(disconnected) == 1
+        assert disconnected[0].was_clean is False
+        assert "consecutive" in disconnected[0].reason.lower()
+
+    async def test_api_error_with_reconnectable_code_triggers_reconnect(self):
+        rt = _make_realtime()
+        reconnected = asyncio.Event()
+
+        async def _raise_api_error():
+            if not reconnected.is_set():
+                reconnected.set()
+                raise APIError(1011, None, None)
+            await asyncio.sleep(10)
+
+        rt._process_events = _raise_api_error
+        rt.connect = AsyncMock()
+
+        emitted: list[object] = []
+        rt.events.send = lambda e: emitted.append(e)
+
+        task = asyncio.create_task(rt._processing_loop())
+        await asyncio.wait_for(reconnected.wait(), timeout=2.0)
+        task.cancel()
+        await task
+
+        rt.connect.assert_called_once()
+        disconnected = [e for e in emitted if isinstance(e, RealtimeDisconnectedEvent)]
+        assert len(disconnected) == 0
+
+    async def test_api_error_non_reconnectable_stops_loop(self):
+        rt = _make_realtime()
+
+        async def _raise_api_error():
+            raise APIError(1006, None, None)
+
+        rt._process_events = _raise_api_error
+
+        emitted: list[object] = []
+        rt.events.send = lambda e: emitted.append(e)
+
+        await rt._processing_loop()
+
+        disconnected = [e for e in emitted if isinstance(e, RealtimeDisconnectedEvent)]
+        assert len(disconnected) == 1
+        assert disconnected[0].was_clean is False

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -539,7 +539,7 @@ class TestGeminiRealtimeProcessingLoop:
             await asyncio.sleep(10)
 
         rt._process_events = _raise_reconnectable
-        rt.connect = AsyncMock()
+        rt._establish_session = AsyncMock()
 
         emitted: list[object] = []
         rt.events.send = lambda e: emitted.append(e)
@@ -549,7 +549,7 @@ class TestGeminiRealtimeProcessingLoop:
         task.cancel()
         await task
 
-        rt.connect.assert_called_once()
+        rt._establish_session.assert_called_once()
         disconnected = [e for e in emitted if isinstance(e, RealtimeDisconnectedEvent)]
         assert len(disconnected) == 0
 
@@ -582,7 +582,7 @@ class TestGeminiRealtimeProcessingLoop:
             await asyncio.sleep(10)
 
         rt._process_events = _raise_api_error
-        rt.connect = AsyncMock()
+        rt._establish_session = AsyncMock()
 
         emitted: list[object] = []
         rt.events.send = lambda e: emitted.append(e)
@@ -592,7 +592,7 @@ class TestGeminiRealtimeProcessingLoop:
         task.cancel()
         await task
 
-        rt.connect.assert_called_once()
+        rt._establish_session.assert_called_once()
         disconnected = [e for e in emitted if isinstance(e, RealtimeDisconnectedEvent)]
         assert len(disconnected) == 0
 

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -514,7 +514,7 @@ class TestGeminiRealtimeProcessingLoop:
         rt = _make_realtime()
 
         async def _raise_closed_error():
-            raise websockets.ConnectionClosedError(Close(1006, "abnormal"), None)
+            raise websockets.ConnectionClosedError(Close(1002, "protocol error"), None)
 
         rt._process_events = _raise_closed_error
 
@@ -526,7 +526,7 @@ class TestGeminiRealtimeProcessingLoop:
         assert len(emitted) == 1
         assert isinstance(emitted[0], RealtimeDisconnectedEvent)
         assert emitted[0].was_clean is False
-        assert "1006" in emitted[0].reason
+        assert "1002" in emitted[0].reason
 
     async def test_reconnectable_close_triggers_reconnect(self):
         rt = _make_realtime()
@@ -600,7 +600,7 @@ class TestGeminiRealtimeProcessingLoop:
         rt = _make_realtime()
 
         async def _raise_api_error():
-            raise APIError(1006, None, None)
+            raise APIError(1002, None, None)
 
         rt._process_events = _raise_api_error
 

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -12,6 +12,7 @@ import websockets
 from aiortc import VideoStreamTrack
 from getstream.video.rtc.track_util import PcmData
 from google import genai
+from google.genai.errors import APIError
 from google.genai.live import AsyncSession
 from google.genai.types import (
     AudioTranscriptionConfigDict,
@@ -79,25 +80,40 @@ DEFAULT_CONFIG = LiveConnectConfigDict(
 )
 
 
-def _should_reconnect(exc: Exception) -> bool:
-    """
-    Temporary errors should typically trigger a reconnect
-    So if the websocket breaks this should return True and trigger a reconnect
-    """
-    # Gemini WS API returns code 1011 on session timeout
-    reconnect_close_codes = [
-        1011,  # Server-side exception or session timeout
-        1012,  # Service restart
-        1013,  # Try again later
-        1014,  # Bad gateway
-    ]
-    if (
-        isinstance(exc, websockets.ConnectionClosedError)
-        and exc.rcvd
-        and exc.rcvd.code in reconnect_close_codes
-    ):
-        return True
-    return False
+RECONNECT_CLOSE_CODES = {
+    1011,  # Server-side exception or session timeout
+    1012,  # Service restart
+    1013,  # Try again later
+    1014,  # Bad gateway
+}
+
+
+RECONNECT = "reconnect"
+STOP = "stop"
+RETRY = "retry"
+
+
+def _classify_loop_error(exc: Exception) -> tuple[str, str, bool]:
+    """Classify a processing-loop exception into (action, reason, was_clean)."""
+    match exc:
+        case websockets.ConnectionClosedOK():
+            return STOP, "WebSocket closed cleanly", True
+
+        case websockets.ConnectionClosedError(rcvd=rcvd):
+            code = rcvd.code if rcvd else None
+            if code in RECONNECT_CLOSE_CODES:
+                return RECONNECT, f"WebSocket code {code}", False
+            reason = (
+                f"WebSocket closed with code {code}"
+                if code
+                else "WebSocket closed unexpectedly"
+            )
+            return STOP, reason, False
+
+        case APIError(code=int(code)) if code in RECONNECT_CLOSE_CODES:
+            return RECONNECT, f"API error code {code}", False
+
+    return RETRY, str(exc), False
 
 
 class GeminiRealtime(realtime.Realtime):
@@ -197,8 +213,8 @@ class GeminiRealtime(realtime.Realtime):
             await self._session.send_realtime_input(text=text)
             return LLMResponseEvent(text="", original=None)
         except Exception as e:
-            # reconnect here in some cases
-            if _should_reconnect(e):
+            action, _, _ = _classify_loop_error(e)
+            if action == RECONNECT:
                 await self.connect()
             logger.exception("Failed to send realtime input to Gemini")
             return LLMResponseEvent(text="", original=None, exception=e)
@@ -460,25 +476,47 @@ class GeminiRealtime(realtime.Realtime):
         return False
 
     async def _processing_loop(self):
-        """
-        Start the loop for receiving messages.
-
-        It also reconnects the underlying session if it's closed.
-        """
+        """Start the loop for receiving and reconnecting on transient errors."""
         logger.debug("Start processing events from Gemini Live API")
+        consecutive_errors = 0
+        max_consecutive_errors = 5
         try:
             while True:
                 try:
                     await self._process_events()
-                except websockets.ConnectionClosedError as e:
-                    if not _should_reconnect(e):
-                        raise e
-                    # Reconnect here for some errors
-                    await self.connect()
-                except Exception:
+                    consecutive_errors = 0
+                except CancelledError:
+                    raise
+                except Exception as exc:
+                    action, reason, was_clean = _classify_loop_error(exc)
+
+                    if action == RECONNECT:
+                        logger.info("Gemini connection lost (%s), reconnecting", reason)
+                        await self.connect()
+                        consecutive_errors = 0
+                        continue
+
+                    if action == STOP:
+                        logger.info("Gemini connection closed: %s", reason)
+                        self._emit_disconnected_event(
+                            reason=reason, was_clean=was_clean
+                        )
+                        return
+
+                    consecutive_errors += 1
                     logger.exception(
-                        "Error while processing events from Gemini Live API"
+                        "Error in Gemini processing loop (%d/%d)",
+                        consecutive_errors,
+                        max_consecutive_errors,
                     )
+                    if consecutive_errors >= max_consecutive_errors:
+                        logger.error(
+                            "Too many consecutive errors, stopping processing loop"
+                        )
+                        self._emit_disconnected_event(
+                            reason="Too many consecutive errors", was_clean=False
+                        )
+                        return
 
         except CancelledError:
             logger.debug("Processing loop has been cancelled")

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -321,6 +321,13 @@ class GeminiRealtime(realtime.Realtime):
         # Stop the processing task first in case we're reconnecting
         await self._stop_processing_task()
 
+        await self._establish_session()
+
+        # Start the loop task
+        await self._start_processing_task()
+
+    async def _establish_session(self):
+        """Create a new Gemini WebSocket session without managing the processing task."""
         logger.debug("Connecting to Gemini live, config set to %s", self._base_config)
         self._real_session = await self._exit_stack.enter_async_context(
             self._client.aio.live.connect(  # type: ignore[arg-type]
@@ -329,9 +336,6 @@ class GeminiRealtime(realtime.Realtime):
         )
         self.connected = True
         logger.info("Gemini live connected to session %s", self._session)
-
-        # Start the loop task
-        await self._start_processing_task()
 
     async def close(self):
         """
@@ -493,7 +497,7 @@ class GeminiRealtime(realtime.Realtime):
 
                     if action == RECONNECT:
                         logger.info("Gemini connection lost (%s), reconnecting", reason)
-                        await self.connect()
+                        await self._establish_session()
                         consecutive_errors = 0
                         continue
 

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -113,6 +113,9 @@ def _classify_loop_error(exc: Exception) -> tuple[str, str, bool]:
         case APIError(code=int(code)) if code in RECONNECT_CLOSE_CODES:
             return RECONNECT, f"API error code {code}", False
 
+        case APIError(code=int(code)):
+            return STOP, f"API error code {code}", False
+
     return RETRY, str(exc), False
 
 

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -488,8 +488,6 @@ class GeminiRealtime(realtime.Realtime):
                 try:
                     await self._process_events()
                     consecutive_errors = 0
-                except CancelledError:
-                    raise
                 except Exception as exc:
                     action, reason, was_clean = _classify_loop_error(exc)
 


### PR DESCRIPTION
## Why

When the network connection is lost during a Gemini Realtime session, the `_processing_loop` enters an infinite error loop. The bare `except Exception` handler logs the error but never breaks the loop, causing endless error spam in logs (#478).

Additionally, the Google genai SDK wraps `websockets.ConnectionClosedError` into its own `APIError`, so the existing `except websockets.ConnectionClosedError` handler was never reached during real network disconnections. Here's what happens under the hood:

1. The WebSocket connection dies (e.g. WiFi off)
2. `websockets` raises `ConnectionClosedError` with code 1011
3. `google.genai.live.AsyncSession._receive()` catches it internally
4. It re-raises as `google.genai.errors.APIError` with code 1006 (abnormal closure)
5. Our old code only caught `websockets.ConnectionClosedError`, so it fell through to the bare `except Exception` which logged and continued the loop forever

## Changes

- Replace `_should_reconnect()` with `_classify_loop_error()` that classifies exceptions into three actions: **reconnect**, **stop**, or **retry**
- Handle `ConnectionClosedOK` with graceful shutdown and `RealtimeDisconnectedEvent`
- Handle non-reconnectable `ConnectionClosedError` with disconnected event instead of re-raising
- Handle `google.genai.errors.APIError` with reconnectable close codes (1011, 1012, 1013, 1014) to trigger reconnection
- `APIError` with non-reconnectable codes (e.g. 1006 abnormal closure) triggers immediate graceful stop
- Cap consecutive unknown errors at 5 before stopping the loop gracefully
- Add 6 unit tests covering all error classification paths

## Out of scope

This PR does **not** fix full session recovery after reconnect. When the Gemini WebSocket reconnects, the audio pipeline (managed by Agent in `agents-core`) still holds references to the dead session, so the agent goes silent. Proper reconnect requires the Agent to listen for `RealtimeDisconnectedEvent` and re-establish the audio pipeline. This is tracked as a follow-up.

## Manual test

Verified with WiFi disconnect during a live Gemini Realtime session: processing loop stops cleanly with a single `Gemini connection closed: API error code 1006` message instead of infinite error spam.

Fixes #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time connection error classification to better distinguish transient reconnects, retries, and permanent disconnects; stops after repeated failures and avoids unnecessary reconnects.
  * Refined session handling to reduce spurious reconnect attempts and ensure clean disconnects emit the appropriate event.

* **Tests**
  * Expanded tests covering websocket and API error scenarios, asserting correct reconnect/stop behavior and emitted disconnect events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->