### PR TITLE
Parametrize max tool calling rounds across LLMs

### DIFF
--- a/plugins/anthropic/vision_agents/plugins/anthropic/anthropic_llm.py
+++ b/plugins/anthropic/vision_agents/plugins/anthropic/anthropic_llm.py
@@ -54,6 +54,7 @@ class ClaudeLLM(LLM):
         model: str,
         api_key: Optional[str] = None,
         client: Optional[AsyncAnthropic] = None,
+        tools_max_rounds: int = 3,
     ):
         """
         Initialize the ClaudeLLM class.
@@ -62,10 +63,12 @@ class ClaudeLLM(LLM):
             model (str): The model to use. https://docs.anthropic.com/en/docs/about-claude/models/overview
             api_key: optional API key. by default loads from ANTHROPIC_API_KEY
             client: optional Anthropic client. by default creates a new client object.
+            tools_max_rounds: max calling rounds for multi-hop tool call. Default - ``3``.
         """
         super().__init__()
         self.events.register_events_from_module(events)
         self.model = model
+        self._tools_max_rounds = max(tools_max_rounds, 1)
         self._pending_tool_uses_by_index: Dict[
             int, Dict[str, Any]
         ] = {}  # index -> {id, name, parts: []}
@@ -170,12 +173,11 @@ class ClaudeLLM(LLM):
             function_calls = self._extract_tool_calls_from_response(original)
             if function_calls:
                 messages = kwargs["messages"][:]
-                MAX_ROUNDS = 3
                 rounds = 0
                 seen: set[tuple[str, str, str]] = set()
                 current_calls = function_calls
 
-                while current_calls and rounds < MAX_ROUNDS:
+                while current_calls and rounds < self._tools_max_rounds:
                     # Execute calls concurrently with dedup
                     triples, seen = await self._dedup_and_execute(
                         current_calls, seen=seen, max_concurrency=8, timeout_s=30
@@ -303,13 +305,12 @@ class ClaudeLLM(LLM):
 
             # Track full message history to reuse across rounds
             messages = kwargs["messages"][:]  # start from prior history
-            MAX_ROUNDS = 3
             rounds = 0
             seen = set()
 
             # 2) While there are tool calls, execute -> return tool_result -> ask again (with tools)
             last_followup_stream = None
-            while accumulated_calls and rounds < MAX_ROUNDS:
+            while accumulated_calls and rounds < self._tools_max_rounds:
                 # Execute calls concurrently with dedup
                 triples, seen = await self._dedup_and_execute(
                     accumulated_calls, seen=seen, max_concurrency=8, timeout_s=30

--- a/plugins/aws/vision_agents/plugins/aws/aws_llm.py
+++ b/plugins/aws/vision_agents/plugins/aws/aws_llm.py
@@ -1,22 +1,21 @@
 import asyncio
+import json
 import logging
 import time
-from typing import Optional, List, TYPE_CHECKING, Any, Dict, cast
-import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+
 import boto3
 from botocore.exceptions import ClientError
-
-from vision_agents.core.llm.llm import LLM, LLMResponseEvent
-from vision_agents.core.llm.llm_types import ToolSchema, NormalizedToolCallItem
-
-
+from vision_agents.core.edge.types import Participant
 from vision_agents.core.llm.events import (
     LLMRequestStartedEvent,
     LLMResponseChunkEvent,
     LLMResponseCompletedEvent,
 )
+from vision_agents.core.llm.llm import LLM, LLMResponseEvent
+from vision_agents.core.llm.llm_types import NormalizedToolCallItem, ToolSchema
+
 from . import events
-from vision_agents.core.edge.types import Participant
 
 if TYPE_CHECKING:
     from vision_agents.core.agents.conversation import Message
@@ -48,6 +47,7 @@ class BedrockLLM(LLM):
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
         aws_profile: Optional[str] = None,
+        tools_max_rounds: int = 3,
     ):
         """
         Initialize the BedrockLLM class.
@@ -59,6 +59,7 @@ class BedrockLLM(LLM):
             aws_secret_access_key: Optional AWS secret access key
             aws_session_token: Optional AWS session token
             aws_profile: Optional AWS profile name (from ~/.aws/credentials or ~/.aws/config)
+            tools_max_rounds: max calling rounds for multi-hop tool call. Default - ``3``.
         """
         super().__init__()
         self.events.register_events_from_module(events)
@@ -78,6 +79,7 @@ class BedrockLLM(LLM):
 
         self._client = None
         self._session_kwargs = session_kwargs
+        self._tools_max_rounds = max(tools_max_rounds, 1)
         self.region_name = region_name
         self.logger = logging.getLogger(__name__)
 
@@ -177,12 +179,11 @@ class BedrockLLM(LLM):
                 if assistant_msg_from_response:
                     messages.append(assistant_msg_from_response)
 
-                MAX_ROUNDS = 3
                 rounds = 0
                 seen: set[tuple[str, str, str]] = set()
                 current_calls = function_calls
 
-                while current_calls and rounds < MAX_ROUNDS:
+                while current_calls and rounds < self._tools_max_rounds:
                     # Execute calls concurrently with dedup
                     triples, seen = await self._dedup_and_execute(
                         cast(List[NormalizedToolCallItem], current_calls),
@@ -456,7 +457,6 @@ class BedrockLLM(LLM):
                 self._process_stream_event(event, text_parts, accumulated_calls)
 
             messages = kwargs["messages"][:]
-            MAX_ROUNDS = 3
             rounds = 0
             seen: set[tuple[str, str, str]] = set()
 
@@ -478,7 +478,7 @@ class BedrockLLM(LLM):
                 }
                 messages.append(assistant_msg_from_stream)
 
-            while accumulated_calls and rounds < MAX_ROUNDS:
+            while accumulated_calls and rounds < self._tools_max_rounds:
                 triples, seen = await self._dedup_and_execute(
                     cast(List[NormalizedToolCallItem], accumulated_calls),
                     seen=seen,

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
@@ -58,6 +58,7 @@ class GeminiLLM(LLM):
         media_resolution: Optional[MediaResolution] = None,
         config: Optional[GenerateContentConfig] = None,
         tools: Optional[List[GeminiTool]] = None,
+        tools_max_rounds: int = 3,
         **kwargs,
     ):
         """
@@ -84,6 +85,7 @@ class GeminiLLM(LLM):
                 - tools.GoogleMaps(): Location-aware queries (Preview)
                 - tools.ComputerUse(): Browser automation (Preview)
                 See: https://ai.google.dev/gemini-api/docs/tools
+            tools_max_rounds: max calling rounds for multi-hop tool call. Default - ``3``.
             **kwargs: Additional arguments passed to GenerateContentConfig constructor.
         """
         super().__init__()
@@ -92,6 +94,7 @@ class GeminiLLM(LLM):
         self.thinking_level = thinking_level
         self.media_resolution = media_resolution
         self._builtin_tools = tools or []
+        self._tools_max_rounds = max(tools_max_rounds, 1)
 
         if config is not None:
             self._base_config: Optional[GenerateContentConfig] = config
@@ -267,13 +270,12 @@ class GeminiLLM(LLM):
         # Check if there were function calls in the response
         if pending_calls:
             # Multi-hop tool calling loop
-            MAX_ROUNDS = 3
             rounds = 0
             current_calls = pending_calls
             cfg_with_tools = kwargs.get("config")
 
             seen: set[str] = set()
-            while current_calls and rounds < MAX_ROUNDS:
+            while current_calls and rounds < self._tools_max_rounds:
                 # Execute tools concurrently with deduplication
                 triples, seen = await self._dedup_and_execute(
                     current_calls, max_concurrency=8, timeout_s=30, seen=seen

--- a/plugins/openai/vision_agents/plugins/openai/chat_completions/chat_completions_llm.py
+++ b/plugins/openai/vision_agents/plugins/openai/chat_completions/chat_completions_llm.py
@@ -46,6 +46,7 @@ class ChatCompletionsLLM(LLM):
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         client: Optional[AsyncOpenAI] = None,
+        tools_max_rounds: int = 3,
     ):
         """
         Initialize the ChatCompletionsLLM class.
@@ -59,6 +60,7 @@ class ChatCompletionsLLM(LLM):
         super().__init__()
         self.model = model
         self.events.register_events_from_module(events)
+        self._tools_max_rounds = max(tools_max_rounds, 1)
         # Track tool calls being accumulated during streaming
         self._pending_tool_calls: Dict[int, Dict[str, Any]] = {}
 
@@ -485,12 +487,11 @@ class ChatCompletionsLLM(LLM):
     ) -> LLMResponseEvent:
         """Execute tool calls and get follow-up response."""
         llm_response: LLMResponseEvent = LLMResponseEvent(original=None, text="")
-        max_rounds = 3
         current_tool_calls = tool_calls
         seen: set[tuple] = set()
         current_messages = list(messages)
 
-        for round_num in range(max_rounds):
+        for round_num in range(self._tools_max_rounds):
             triples, seen = await self._dedup_and_execute(
                 current_tool_calls,  # type: ignore[arg-type]
                 max_concurrency=8,
@@ -613,7 +614,7 @@ class ChatCompletionsLLM(LLM):
                 i += 1
 
             # Continue if there are more tool calls
-            if next_tool_calls and round_num < max_rounds - 1:
+            if next_tool_calls and round_num < self._tools_max_rounds - 1:
                 current_tool_calls = next_tool_calls
                 continue
 

--- a/plugins/openai/vision_agents/plugins/openai/chat_completions/chat_completions_llm.py
+++ b/plugins/openai/vision_agents/plugins/openai/chat_completions/chat_completions_llm.py
@@ -56,6 +56,7 @@ class ChatCompletionsLLM(LLM):
             api_key: optional API key. By default, loads from OPENAI_API_KEY environment variable.
             base_url: optional base url. By default, loads from OPENAI_BASE_URL environment variable.
             client: optional `AsyncOpenAI` client. By default, creates a new client object.
+            tools_max_rounds: max calling rounds for multi-hop tool call. Default - ``3``.
         """
         super().__init__()
         self.model = model

--- a/plugins/openrouter/vision_agents/plugins/openrouter/openrouter_llm.py
+++ b/plugins/openrouter/vision_agents/plugins/openrouter/openrouter_llm.py
@@ -51,6 +51,7 @@ class OpenRouterLLM(OpenAILLM):
         base_url: str = "https://openrouter.ai/api/v1",
         model: str = "openrouter/andromeda-alpha",
         max_tokens: int | None = None,
+        tools_max_rounds: int = 3,
         **kwargs: Any,
     ) -> None:
         """Initialize OpenRouter LLM.
@@ -62,6 +63,7 @@ class OpenRouterLLM(OpenAILLM):
             max_tokens: This sets the upper limit for the number of tokens the model can generate in response.
                 It won’t produce more than this limit.
                 The maximum value is the context length minus the prompt length.
+            tools_max_rounds: max calling rounds for multi-hop tool call. Default - ``3``.
             **kwargs: Additional arguments passed to OpenAI LLM.
         """
         if api_key is None:
@@ -75,6 +77,7 @@ class OpenRouterLLM(OpenAILLM):
         # For tracking streaming tool calls in Chat Completions mode
         self._pending_tool_calls: Dict[int, Dict[str, Any]] = {}
         self._max_tokens = max_tokens
+        self._tools_max_rounds = max(tools_max_rounds, 1)
 
     def _is_auto_model(self, model: Optional[str] = None) -> bool:
         """Check if the model is a meta/auto model that may not support tools."""
@@ -506,7 +509,6 @@ class OpenRouterLLM(OpenAILLM):
         speaking "Now I'll search..." between each tool call.
         """
         llm_response: LLMResponseEvent = LLMResponseEvent(original=None, text="")
-        max_rounds = 3
         current_tool_calls = tool_calls
         seen: set[tuple] = set()
         current_messages = list(messages)
@@ -518,7 +520,7 @@ class OpenRouterLLM(OpenAILLM):
                 tc.get("arguments_json"),
             )
 
-        for round_num in range(max_rounds):
+        for round_num in range(self._tools_max_rounds):
             triples, seen = await self._dedup_and_execute(
                 current_tool_calls,  # type: ignore[arg-type]
                 max_concurrency=8,
@@ -635,7 +637,7 @@ class OpenRouterLLM(OpenAILLM):
                     llm_response = LLMResponseEvent(original=chunk, text=total_text)
 
             # If more tool calls, continue the loop
-            if next_tool_calls and round_num < max_rounds - 1:
+            if next_tool_calls and round_num < self._tools_max_rounds - 1:
                 current_tool_calls = next_tool_calls
                 continue
 

--- a/plugins/xai/vision_agents/plugins/xai/llm.py
+++ b/plugins/xai/vision_agents/plugins/xai/llm.py
@@ -47,6 +47,7 @@ class XAILLM(LLM):
         model: str = "grok-4-latest",
         api_key: Optional[str] = None,
         client: Optional[AsyncClient] = None,
+        tools_max_rounds: int = 3,
     ):
         """
         Initialize the XAILLM class.
@@ -55,12 +56,14 @@ class XAILLM(LLM):
             model (str): The xAI model to use. Defaults to "grok-4-latest"
             api_key: optional API key. by default loads from XAI_API_KEY
             client: optional xAI client. by default creates a new client object.
+            tools_max_rounds: max calling rounds for multi-hop tool call. Default - ``3``.
         """
         super().__init__()
         self.events.register_events_from_module(events)
         self.model = model
         self.xai_chat: Optional["Chat"] = None
         self.conversation = None
+        self._tools_max_rounds = max(tools_max_rounds, 1)
 
         if client is not None:
             self.client = client
@@ -335,11 +338,10 @@ class XAILLM(LLM):
             LLM response with tool results
         """
         llm_response: Optional[LLMResponseEvent[Response]] = None
-        max_rounds = 3
         current_tool_calls = tool_calls
         seen: set[tuple] = set()
 
-        for round_num in range(max_rounds):
+        for round_num in range(self._tools_max_rounds):
             triples, seen = await self._dedup_and_execute(
                 current_tool_calls,
                 max_concurrency=8,
@@ -400,7 +402,7 @@ class XAILLM(LLM):
                 if llm_response and llm_response.original:
                     self.xai_chat.append(llm_response.original)
 
-                if pending_tool_calls and round_num < max_rounds - 1:
+                if pending_tool_calls and round_num < self._tools_max_rounds - 1:
                     current_tool_calls = pending_tool_calls
                     continue
                 else:
@@ -413,7 +415,7 @@ class XAILLM(LLM):
                 self.xai_chat.append(response)
 
                 next_tool_calls = self._extract_tool_calls_from_response(response)
-                if next_tool_calls and round_num < max_rounds - 1:
+                if next_tool_calls and round_num < self._tools_max_rounds - 1:
                     current_tool_calls = next_tool_calls
                     continue
                 else:

--- a/plugins/xai/vision_agents/plugins/xai/llm.py
+++ b/plugins/xai/vision_agents/plugins/xai/llm.py
@@ -328,7 +328,7 @@ class XAILLM(LLM):
     ) -> LLMResponseEvent[Response]:
         """
         Handle tool calls by executing them and getting a follow-up response.
-        Supports multi-round tool calling (max 3 rounds).
+        Supports multi-round tool calling.
 
         Args:
             tool_calls: List of tool calls to execute


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable tools_max_rounds setting to all LLM providers (Anthropic, AWS, Gemini, OpenAI, OpenRouter, XAI). Controls the maximum consecutive multi-hop tool-calling rounds per LLM instance (default: 3, minimum enforced: 1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->