### PR TITLE
chore: add commit/pr skills and GitHub PR template

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: commit
+description: Create a git commit for the Vision-Agents repo.
+---
+
+# Commit (Vision-Agents)
+
+## Rules
+
+- Before committing, check the current branch. If on `main`, warn and ask whether to create a new branch first.
+- Use conventional commits format: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, etc.
+- Keep the subject line (first line) at 72 characters or fewer. If it does not fit, the commit is probably doing too much.
+- One logical change per commit. Do not bundle unrelated changes.
+- Stage files individually by name. Never use `git add .` or `git add -A`.
+- Commit message body (when needed) focuses on why, not what.
+
+## Pre-commit hooks
+
+- The repo runs ruff (check + format), mypy, trailing-whitespace and eof fixes on commit. Let them run.
+- Never pass `--no-verify`. If a hook modifies files, re-stage the changed files and retry the commit. If mypy or another check fails, fix the underlying issue before committing.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: pr
+description: Create a draft pull request for the Vision-Agents repo using gh CLI.
+---
+
+# Pull Request (Vision-Agents)
+
+## Before creating
+
+- Run `uv run --no-sync dev.py check` (ruff + mypy + unit tests). Fix anything it reports.
+- Do not run integration tests locally. CI handles them.
+- If the change is user-facing (public API break, new feature, bug fix), update `CHANGELOG.md` per the rules in `CLAUDE.md` before opening the PR.
+
+## Creating
+
+- Use `gh pr create --draft`.
+- Follow `.github/pull_request_template.md`. It is a single `## Why` section.
+- Read every commit on the branch before writing `## Why`. Do not summarise from the latest commit alone.
+- `## Why` must cover the motivation and enough context about the current state that a reviewer can evaluate the change. It is not a description of what changed, the diff already does that.
+- If the change relates to a public GitHub issue, link it inline within `## Why` (for example, "users reported X (#478), which happens because Y"), not as a trailing `Fixes #N`.
+
+## Rules
+
+- Always draft. The human publishes.
+- Push the branch before creating the PR.
+- Do not paste CI output, lint output, or tool logs into the body.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,6 +7,7 @@ description: Create a draft pull request for the Vision-Agents repo using gh CLI
 
 ## Before creating
 
+- One logical change per PR. If the branch covers more than one independent change, split it into separate PRs before writing the body.
 - Run `uv run --no-sync dev.py check` (ruff + mypy + unit tests). Fix anything it reports.
 - Do not run integration tests locally. CI handles them.
 - If the change is user-facing (public API break, new feature, bug fix), update `CHANGELOG.md` per the rules in `CLAUDE.md` before opening the PR.
@@ -14,9 +15,10 @@ description: Create a draft pull request for the Vision-Agents repo using gh CLI
 ## Creating
 
 - Use `gh pr create --draft`.
-- Follow `.github/pull_request_template.md`. It is a single `## Why` section.
-- Read every commit on the branch before writing `## Why`. Do not summarise from the latest commit alone.
+- Follow `.github/pull_request_template.md`. It has two sections: `## Why` (required) and `## Changes` (optional).
+- Read every commit on the branch before writing the body. Do not summarise from the latest commit alone.
 - `## Why` must cover the motivation and enough context about the current state that a reviewer can evaluate the change. It is not a description of what changed, the diff already does that.
+- `## Changes` is a short, high-level bullet list of the main changes. Omit it entirely when the diff is small or self-evident (e.g. a dependency bump). Never let `## Changes` dissolve into a file-by-file list or turn into per-bullet justifications — that belongs in `## Why`.
 - If the change relates to a public GitHub issue, link it inline within `## Why` (for example, "users reported X (#478), which happens because Y"), not as a trailing `Fixes #N`.
 
 ## Rules

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,7 +7,7 @@ description: Create a draft pull request for the Vision-Agents repo using gh CLI
 
 ## Before creating
 
-- One logical change per PR. If the branch covers more than one independent change, split it into separate PRs before writing the body.
+- Before writing the PR body, run `git log main..HEAD --oneline` to review all commits on the branch. If the branch contains more than one independent logical change, STOP and ask the user whether to split the branch into separate PRs before proceeding.
 - Run `uv run --no-sync dev.py check` (ruff + mypy + unit tests). Fix anything it reports.
 - Do not run integration tests locally. CI handles them.
 - If the change is user-facing (public API break, new feature, bug fix), update `CHANGELOG.md` per the rules in `CLAUDE.md` before opening the PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,3 @@
 
 ## Changes
 <!-- Short bullet list of the main changes. Omit this section if the diff is small enough to speak for itself. -->
--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,6 @@
 ## Why
 <!-- What problem does this solve, and what context does a reviewer need to evaluate it? -->
+
+## Changes
+<!-- Short bullet list of the main changes. Omit this section if the diff is small enough to speak for itself. -->
+-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+## Why
+<!-- What problem does this solve, and what context does a reviewer need to evaluate it? -->

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,8 @@ profile.html
 
 /opencode.json
 .ralph-tui/
-.claude/
+.claude/*
+!.claude/skills/
 
 .uv-cache/
 


### PR DESCRIPTION
## Why

There is no shared convention in the repo for how commits and PRs should look, so the shape varies per author. Adding a GitHub PR template gives contributors a consistent starting point, and checking in `.claude/skills/{commit,pr}/SKILL.md` codifies the same rules (conventional commits, one logical change, no `--no-verify`, draft-first PRs) so Claude follows them automatically when invoked via `/commit` or `/pr`.

The template has a required `## Why` and an optional `## Changes` bullet list. `## Changes` is meant to be omitted when the diff is small enough to speak for itself (e.g. a dependency bump), so it does not add ceremony to trivial PRs. The pr skill also enforces an explicit `git log main..HEAD --oneline` review before writing the body so multi-topic branches get split instead of merged as one PR.

## Changes

- New `.github/pull_request_template.md` with `## Why` (required) and `## Changes` (optional).
- New `.claude/skills/commit/SKILL.md` and `.claude/skills/pr/SKILL.md` codifying commit/PR rules for this repo.
- `.gitignore` now tracks `.claude/skills/` while still ignoring the rest of `.claude/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added commit guidelines: conventional short subjects (≤72 chars), one logical change per commit, stage files individually, and write commit bodies focused on “why”; pre-commit checks must run and be re-run if they modify files.
  * Added PR workflow and template: pre-creation checklist, draft PR guidance, structured PR body requiring motivation and an optional concise changes list.
  * Adjusted ignore rules so developer skill guides remain tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->