### PR TITLE
ci: pass INWORLD_API_KEY to e2e test job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -85,6 +85,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
       SARVAM_API_KEY: ${{ secrets.SARVAM_API_KEY }}
+      INWORLD_API_KEY: ${{ secrets.INWORLD_API_KEY }}
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why
The daily e2e workflow started failing after the Inworld Realtime plugin landed (#502) because the test job did not expose `INWORLD_API_KEY` to the environment, so the plugin's integration tests could not authenticate. The `INWORLD_API_KEY` secret is already configured in the repository settings; this wires it through to the job alongside the other provider keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow configuration to include necessary API credentials for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->