### PR TITLE
Tighten commit and pr skill docs

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -7,14 +7,11 @@ description: Create a git commit for the Vision-Agents repo.
 
 ## Rules
 
-- Before committing, check the current branch. If on `main`, warn and ask whether to create a new branch first.
-- Use conventional commits format: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, etc.
-- Keep the subject line (first line) at 72 characters or fewer. If it does not fit, the commit is probably doing too much.
-- One logical change per commit. Do not bundle unrelated changes.
-- Stage files individually by name. Never use `git add .` or `git add -A`.
-- Commit message body (when needed) focuses on why, not what.
+- If on `main`, warn and ask whether to create a new branch first.
+- Use conventional commits. Keep the subject line ≤72 chars.
+- One logical change per commit. Stage files individually by name, never `git add .` / `-A`.
 
 ## Pre-commit hooks
 
-- The repo runs ruff (check + format), mypy, trailing-whitespace and eof fixes on commit. Let them run.
-- Never pass `--no-verify`. If a hook modifies files, re-stage the changed files and retry the commit. If mypy or another check fails, fix the underlying issue before committing.
+- The repo runs ruff (check + format), mypy, trailing-whitespace and eof fixes on commit.
+- Never pass `--no-verify`. If a hook modifies files, re-stage and retry. If mypy or another check fails, fix the root cause before committing.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,22 +7,15 @@ description: Create a draft pull request for the Vision-Agents repo using gh CLI
 
 ## Before creating
 
-- Before writing the PR body, run `git log main..HEAD --oneline` to review all commits on the branch. If the branch contains more than one independent logical change, STOP and ask the user whether to split the branch into separate PRs before proceeding.
-- Run `uv run --no-sync dev.py check` (ruff + mypy + unit tests). Fix anything it reports.
-- Do not run integration tests locally. CI handles them.
-- If the change is user-facing (public API break, new feature, bug fix), update `CHANGELOG.md` per the rules in `CLAUDE.md` before opening the PR.
+- Run `git log main..HEAD --oneline`. If the branch contains more than one independent logical change, STOP and ask the user whether to split it before proceeding.
+- Run `uv run --no-sync dev.py check`.
+- Do not run integration tests locally, CI handles them.
+- If the change is user-facing (public API break, new feature, bug fix), update `CHANGELOG.md` per the rules in `CLAUDE.md`.
 
 ## Creating
 
-- Use `gh pr create --draft`.
-- Follow `.github/pull_request_template.md`. It has two sections: `## Why` (required) and `## Changes` (optional).
-- Read every commit on the branch before writing the body. Do not summarise from the latest commit alone.
-- `## Why` must cover the motivation and enough context about the current state that a reviewer can evaluate the change. It is not a description of what changed, the diff already does that.
-- `## Changes` is a short, high-level bullet list of the main changes. Omit it entirely when the diff is small or self-evident (e.g. a dependency bump). Never let `## Changes` dissolve into a file-by-file list or turn into per-bullet justifications — that belongs in `## Why`.
-- If the change relates to a public GitHub issue, link it inline within `## Why` (for example, "users reported X (#478), which happens because Y"), not as a trailing `Fixes #N`.
-
-## Rules
-
-- Always draft. The human publishes.
-- Push the branch before creating the PR.
-- Do not paste CI output, lint output, or tool logs into the body.
+- Always `gh pr create --draft`. Push the branch first.
+- Follow `.github/pull_request_template.md`. Read every commit on the branch, do not summarise from the latest commit alone.
+- `## Why` is motivation + context. `## Changes`, if included, is high-level; never per-bullet justifications, those belong in `## Why`.
+- Link public GitHub issues inline within `## Why` (e.g. "users reported X (#478)"), not as a trailing `Fixes #N`.
+- Do not paste CI, lint, or tool output in the body.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -8,7 +8,7 @@ description: Create a draft pull request for the Vision-Agents repo using gh CLI
 ## Before creating
 
 - Run `git log main..HEAD --oneline`. If the branch contains more than one independent logical change, STOP and ask the user whether to split it before proceeding.
-- Run `uv run --no-sync dev.py check`.
+- Run `uv run --no-sync dev.py check`. Skip if the diff does not touch Python code (`*.py`) or `pyproject.toml` — e.g. docs-only, `.gitignore`, `.github/`, or `.claude/` changes.
 - Do not run integration tests locally, CI handles them.
 - If the change is user-facing (public API break, new feature, bug fix), update `CHANGELOG.md` per the rules in `CLAUDE.md`.
 


### PR DESCRIPTION
## Why

The `commit` and `pr` SKILL.md files had drifted into verbose prose (~27 lines in `/pr`, ~15 in `/commit`), where each rule carried a paragraph of justification. Hard to scan for humans, inefficient for Claude to re-ingest each session.

This became concrete in #510: despite the skill being loaded, the session writing that PR still produced a verbose, Changes-disguised-as-Why body. The skill's own prose was modelling the pattern it was supposed to prevent.

Refinement rule applied here: drop anything the LLM already knows from training, collapse DRY overlaps with the template file, and keep only project-specific commands and anti-drift warnings. `/pr` went from 27 to 17 lines, `/commit` from 15 to 10.

A separate refinement surfaced while testing the tighter skill: `dev.py check` was being run on docs-only PRs, wasting ~2 minutes and risking unrelated test failures (#510 hit this). Added an explicit skip rule: do not run the check when the diff touches only non-Python files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined commit message guidelines while maintaining conventional commit standards and reinforcing the 72-character subject line requirement.
  * Refined pull request workflow documentation with simplified checklist requirements, conditional testing criteria, and consolidated PR creation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->