### PR TITLE
fix(gemini): route MCP tool schemas through parameters_json_schema

### DIFF
--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -24,6 +24,59 @@ class TestGeminiLLM:
         messages2 = GeminiLLM._normalize_message(advanced)
         assert messages2[0].original is not None
 
+    async def test_convert_tools_routes_mcp_schema_to_parameters_json_schema(
+        self, llm: GeminiLLM
+    ):
+        tools = [
+            {
+                "name": "search_docs",
+                "description": "Search knowledge base",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"}
+                    },
+                    "required": ["query"],
+                    "additionalProperties": False,
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                },
+            }
+        ]
+
+        result = llm._convert_tools_to_provider_format(tools)
+
+        decl = result[0]["function_declarations"][0]
+        assert "parameters" not in decl
+        schema = decl["parameters_json_schema"]
+        assert "$schema" not in schema
+        assert schema["additionalProperties"] is False
+        assert schema["required"] == ["query"]
+        assert schema["properties"]["query"]["type"] == "string"
+
+    async def test_convert_tools_strips_nested_schema_meta(self, llm: GeminiLLM):
+        tools = [
+            {
+                "name": "nested",
+                "description": "",
+                "parameters_schema": {
+                    "type": "object",
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "inner": {
+                            "type": "object",
+                            "$schema": "http://json-schema.org/draft-07/schema#",
+                        }
+                    },
+                },
+            }
+        ]
+
+        schema = llm._convert_tools_to_provider_format(tools)[0][
+            "function_declarations"
+        ][0]["parameters_json_schema"]
+        assert "$schema" not in schema
+        assert "$schema" not in schema["properties"]["inner"]
+
     @pytest.fixture
     async def llm(self):
         llm = GeminiLLM()

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
@@ -29,6 +29,21 @@ if TYPE_CHECKING:
 DEFAULT_MODEL = "gemini-3.1-pro-preview"
 
 
+_GEMINI_UNSUPPORTED_SCHEMA_KEYS = frozenset({"$schema"})
+
+
+def _strip_unsupported_schema_keys(node: Any) -> Any:
+    if isinstance(node, dict):
+        return {
+            k: _strip_unsupported_schema_keys(v)
+            for k, v in node.items()
+            if k not in _GEMINI_UNSUPPORTED_SCHEMA_KEYS
+        }
+    if isinstance(node, list):
+        return [_strip_unsupported_schema_keys(item) for item in node]
+    return node
+
+
 class GeminiLLM(LLM):
     """
     The GeminiLLM class provides full/native access to the gemini SDK methods.
@@ -470,7 +485,9 @@ class GeminiLLM(LLM):
                 {
                     "name": tool["name"],
                     "description": tool.get("description", ""),
-                    "parameters": tool["parameters_schema"],
+                    "parameters_json_schema": _strip_unsupported_schema_keys(
+                        tool["parameters_schema"]
+                    ),
                 }
             )
 


### PR DESCRIPTION
## Why

Gemini rejects tool declarations whose `parameters` field contains JSON Schema fields outside its OpenAPI 3.0 subset. Two of these routinely appear in MCP tool schemas:

- `$schema` — emitted by Mintlify-hosted MCP servers (e.g. `visionagents.ai/mcp`). `google.genai.types.Tool` is pydantic with `extra="forbid"`, so validation fails with `ValidationError: extra_forbidden` on `function_declarations.*.parameters.$schema`.
- `additionalProperties` — injected by `MCPToolConverter._convert_input_schema` when absent, then serialized by the SDK as `additional_properties`. Gemini's REST endpoint rejects it with `400: Invalid JSON payload received. Unknown name "additional_properties" at 'tools[0].function_declarations[0].parameters'`.

Both blocked any voice agent that attaches an MCP server to a Gemini LLM.

## Changes

- `_convert_tools_to_provider_format` now emits `parameters_json_schema` (`parametersJsonSchema` on the wire) instead of `parameters`. This is Gemini's documented JSON Schema path, which supports `$id`, `$defs`, `$ref`, `$anchor`, `additionalProperties`, and `propertyOrdering`.
- `$schema` is stripped recursively: it is not in the supported keyword list even for the JSON Schema path.

Verified against `gemini-3-flash-preview` with the Mintlify MCP server at `visionagents.ai/mcp`: pydantic validation passes, the REST endpoint accepts the request, and multi-hop tool calling (two sequential MCP tool calls followed by a grounded text response) completes end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool parameter schemas in the Gemini plugin: tool declarations now use a JSON-schema payload and unsupported metadata is stripped, resulting in more reliable tool submissions to the API.

* **Tests**
  * Added unit tests validating schema conversion, metadata stripping (including nested cases), and the updated parameter formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->