### PR TITLE
docs(skills): flag GitHub paragraph hard-wrap in pr skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -19,3 +19,4 @@ description: Create a draft pull request for the Vision-Agents repo using gh CLI
 - `## Why` is motivation + context. `## Changes`, if included, is high-level; never per-bullet justifications, those belong in `## Why`.
 - Link public GitHub issues inline within `## Why` (e.g. "users reported X (#478)"), not as a trailing `Fixes #N`.
 - Do not paste CI, lint, or tool output in the body.
+- Do not hard-wrap paragraphs. GitHub renders each newline inside a paragraph as a visible line break, so a 72-column-wrapped paragraph becomes a staircase. Write each paragraph or bullet as one unbroken line; rely on the browser to soft-wrap. Only use newlines to separate paragraphs, list items, or block elements.


### PR DESCRIPTION
## Why

The `pr` skill previously left paragraph wrapping unaddressed, and the agent defaulted to 72-column hard-wrapping as it would for a commit body. GitHub's GFM renders every newline inside a paragraph as a visible line break, so a hard-wrapped PR description renders as a staircase (e.g. #513 before this rule was applied). The fix is one extra rule telling the agent to write paragraphs and bullets as single unbroken lines and rely on the browser to soft-wrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR creation guidelines to clarify text formatting conventions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->