### PR TITLE
chore(coderabbit): tune review config to reduce noise

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,7 +29,7 @@ reviews:
     auto_pause_after_reviewed_commits: 50
 
   path_instructions:
-    - path: "/**/test_*.py"
+    - path: "**/test_*.py"
       instructions: |
         Review pytest tests. Project uses uv.
         - Integration tests must not mock; use real clients.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,12 +1,37 @@
+language: "en-US"
+tone_instructions: "Be direct, terse, pragmatic. No emojis, no praise, no filler, no metaphors. Findings are actionable items only."
+
 reviews:
-  #...
+  profile: "chill"
+
+  high_level_summary: false
+
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
+
+  poem: false
+  in_progress_fortune: false
+  review_status: false
+
+  enable_prompt_for_ai_agents: false
+
+  auto_review:
+    enabled: true
+    drafts: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 50
+
   path_instructions:
     - path: "/**/test_*.py"
       instructions: |
-        Review the following unit test code written using the pytest test library. Ensure that:
-        - The code adheres to best practices associated with Pytest. The project uses uv.  
-        - Descriptive test names are used to clearly convey the intent of each test.
-        - For Integration tests, we should avoid mocking. Integration tests of classes should use the actual client. 
-        - The test should convey actual value. Tests which initialise a class and test the values of those classes should be discouraged 
-        - Discourage verbosity and redundant tests    
-tone_instructions: "If you must write a poem, write it in the style of Sylvia Plath."
+        Review pytest tests. Project uses uv.
+        - Integration tests must not mock; use real clients.
+        - Assert behavior and outputs, not initialization or call paths.
+        - Discourage verbosity and redundant tests.


### PR DESCRIPTION
## Why

CodeRabbit is currently noisy in a few ways that distract from real review signal: it injects its own summary into the PR description (which our `pr` skill already writes), spams walkthrough comments with sequence diagrams / related-PRs / suggested-reviewers / poems / fortune messages, and attaches a large "Prompt for AI agents" block to every inline comment. The previous `tone_instructions` also asked for poems in the style of Sylvia Plath, which is not what we want from a code review bot.

Separately, draft PRs were being skipped (CodeRabbit default), but the desired workflow is the opposite: review during draft so findings are addressed before the PR is handed to a human reviewer.

## Changes

- Enable reviews on draft PRs and raise the auto-pause threshold from 5 to 50 commits.
- Disable PR-description summary (`high_level_summary`), walkthrough decor (changed-files summary, sequence diagrams, effort estimate, related issues/PRs, suggested labels/reviewers), poems, fortunes, review-status messages, and the per-comment AI-agents prompt block.
- Replace `tone_instructions` with a terse, pragmatic directive.
- Tighten the pytest `path_instructions` to drop redundancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal review configuration: enforced an "actionable-only" tone, enabled automated draft and incremental reviews with a commit-based auto-pause threshold, and disabled several non-actionable review outputs (summaries, diagrams, effort estimates, prompting, and suggestion features).
  * Streamlined test guidance: tightened test file globs, prefer real clients over mocks for integration tests, and emphasize behavior/output assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->