### PR TITLE
chore(coderabbit): disable finishing_touches and pre_merge_checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,6 +22,24 @@ reviews:
 
   enable_prompt_for_ai_agents: false
 
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
+
   auto_review:
     enabled: true
     drafts: true


### PR DESCRIPTION
## Why

Follow-up to #517. After the first round of tuning, two more sources of CodeRabbit walkthrough noise remained: the "✨ Finishing Touches" block (offers to generate docstrings, unit tests, simplifications) and the "Pre-merge checks" block (validates PR title, description, docstring coverage, linked-issue assessment). The Finishing Touches prompts are not how we want code or tests written here. PR title and description quality is already enforced locally by our `pr` skill, so the pre-merge checks duplicate that without adding value.

## Changes

- Disable all three `reviews.finishing_touches` recipes (`docstrings`, `unit_tests`, `simplify`).
- Set every `reviews.pre_merge_checks` mode to `"off"` (`docstrings`, `title`, `description`, `issue_assessment`).