### PR TITLE
fix(tests): drop forbidden future-annotations import

### DIFF
--- a/tests/test_pyproject_sources.py
+++ b/tests/test_pyproject_sources.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 import tomllib
 


### PR DESCRIPTION
## Why

`tests/test_pyproject_sources.py` started with `from __future__ import annotations`, which the project's `CLAUDE.md` explicitly forbids. The file only uses built-in generics (`list[...]`, `tuple[...]`) that are native on Python 3.10+, so the import is unnecessary and the removal is safe.

Doubling as a smoke test for the recently tuned CodeRabbit configuration to verify the `**/test_*.py` `path_instructions` glob now matches.