### PR TITLE
Anam plugin optimizations

### DIFF
--- a/plugins/anam/README.md
+++ b/plugins/anam/README.md
@@ -74,6 +74,7 @@ AnamAvatarPublisher(
     client_options=None,  # Optional Anam ClientOptions for advanced configuration
     connect_timeout=None,  # Seconds to wait for connection (None = wait indefinitely)
     session_ready_timeout=None,  # Seconds to wait for session ready (None = wait indefinitely)
+    audio_sample_rate=16000,  # TTS audio sample rate sent to Anam
     width=1920,  # Output video width in pixels
     height=1080,  # Output video height in pixels
 )
@@ -82,9 +83,11 @@ AnamAvatarPublisher(
 ## How It Works
 
 1. **Anam Connection**: Connects to Anam's avatar service and waits for the session to become ready
-2. **Audio Forwarding**: TTS audio from the agent is resampled to 24kHz mono and streamed to Anam
+2. **Audio Forwarding**: TTS audio from the agent is streamed directly to Anam using the configured sample rate
 3. **Avatar Generation**: Anam generates synchronized avatar video and lip-synced audio from the input
 4. **Video Streaming**: Avatar video and audio frames are streamed back to call participants via GetStream Edge
+
+Set `audio_sample_rate` to match your TTS output sample rate.
 
 ## Requirements
 

--- a/plugins/anam/tests/test_anam_plugin.py
+++ b/plugins/anam/tests/test_anam_plugin.py
@@ -1,5 +1,10 @@
+import asyncio
+from typing import AsyncIterator, cast
+
+from anam import AgentAudioInputConfig, AgentAudioInputStream, Session
 import pytest
 from getstream.video.rtc import audio_track
+from getstream.video.rtc.track_util import AudioFormat, PcmData
 from vision_agents.core.events import EventManager
 from vision_agents.core.llm.events import (
     RealtimeAudioOutputDoneEvent,
@@ -26,6 +31,49 @@ class DummyAgent:
         self.events.register(RealtimeAudioOutputEvent)
         self.events.register(RealtimeAudioOutputDoneEvent)
         self.events.register(TurnStartedEvent)
+
+
+class FakeAudioInputStream:
+    def __init__(self):
+        self.chunks: list[bytes] = []
+        self.sequence_ended = False
+
+    async def send_audio_chunk(self, chunk: bytes) -> None:
+        self.chunks.append(chunk)
+
+    async def end_sequence(self) -> None:
+        self.sequence_ended = True
+
+
+class FakeSession:
+    def __init__(self):
+        self.configs: list[AgentAudioInputConfig] = []
+        self.stream = FakeAudioInputStream()
+
+    def create_agent_audio_input_stream(
+        self, config: AgentAudioInputConfig
+    ) -> AgentAudioInputStream:
+        self.configs.append(config)
+        return cast(AgentAudioInputStream, self.stream)
+
+    async def audio_frames(self) -> AsyncIterator[object]:
+        while True:
+            await asyncio.sleep(3600)
+            yield None
+
+    async def video_frames(self) -> AsyncIterator[object]:
+        while True:
+            await asyncio.sleep(3600)
+            yield None
+
+
+def _make_pcm() -> PcmData:
+    return PcmData.from_bytes(
+        b"\x01\x00" * 4000,
+        sample_rate=16000,
+        channels=1,
+        format=AudioFormat.S16,
+    )
 
 
 class TestAnamAvatarPublisher:
@@ -77,3 +125,50 @@ class TestAnamAvatarPublisher:
         assert agent.events.has_subscribers(RealtimeAudioOutputEvent)
         assert agent.events.has_subscribers(RealtimeAudioOutputDoneEvent)
         assert agent.events.has_subscribers(TurnStartedEvent)
+
+    async def test_creates_audio_input_stream_with_configured_sample_rate(self):
+        pub = _make_publisher(audio_sample_rate=24000)
+        session = FakeSession()
+        pub._real_session = cast(Session, session)
+
+        pub._create_audio_input_stream()
+
+        assert pub._audio_input_stream is session.stream
+        assert len(session.configs) == 1
+        assert session.configs[0].sample_rate == 24000
+        assert session.configs[0].channels == 1
+        assert session.configs[0].encoding == "pcm_s16le"
+
+    async def test_send_audio_sends_single_original_pcm_payload(self):
+        pub = _make_publisher()
+        session = FakeSession()
+        pub._real_session = cast(Session, session)
+        pcm = _make_pcm()
+
+        await pub._send_audio(pcm)
+
+        assert session.stream.chunks == [pcm.to_bytes()]
+        assert len(session.configs) == 1
+
+    async def test_connect_creates_audio_input_stream_before_receiver_tasks(self):
+        pub = _make_publisher(audio_sample_rate=22050)
+        session = FakeSession()
+        pub._real_session = cast(Session, session)
+        pub._connected.set()
+        pub._session_ready.set()
+
+        await pub._connect()
+
+        assert pub._audio_input_stream is session.stream
+        assert len(session.configs) == 1
+        assert session.configs[0].sample_rate == 22050
+        assert pub._audio_receiver_task is not None
+        assert pub._video_receiver_task is not None
+
+        pub._audio_receiver_task.cancel()
+        pub._video_receiver_task.cancel()
+        await asyncio.gather(
+            pub._audio_receiver_task,
+            pub._video_receiver_task,
+            return_exceptions=True,
+        )

--- a/plugins/anam/vision_agents/plugins/anam/anam_avatar_publisher.py
+++ b/plugins/anam/vision_agents/plugins/anam/anam_avatar_publisher.py
@@ -57,6 +57,7 @@ class AnamAvatarPublisher(AudioPublisher, VideoPublisher):
         client_options: ClientOptions | None = None,
         connect_timeout: float | None = None,
         session_ready_timeout: float | None = None,
+        audio_sample_rate: int = 16000,
         width: int = 1920,
         height: int = 1080,
     ):
@@ -70,6 +71,7 @@ class AnamAvatarPublisher(AudioPublisher, VideoPublisher):
                 None means wait indefinitely.
             session_ready_timeout: Seconds to wait for the session to become ready.
                 None means wait indefinitely.
+            audio_sample_rate: TTS audio sample rate sent to Anam.
             width: Output video width in pixels.
             height: Output video height in pixels.
         """
@@ -101,6 +103,7 @@ class AnamAvatarPublisher(AudioPublisher, VideoPublisher):
 
         self._connect_timeout = connect_timeout
         self._session_ready_timeout = session_ready_timeout
+        self._audio_sample_rate = audio_sample_rate
 
         self._connected = asyncio.Event()
         self._session_ready = asyncio.Event()
@@ -184,20 +187,25 @@ class AnamAvatarPublisher(AudioPublisher, VideoPublisher):
                 logger.warning("Failed to send audio frame", exc_info=True)
 
     async def _send_audio(self, pcm: PcmData) -> None:
-        if self._audio_input_stream is None:
-            self._audio_input_stream = self._session.create_agent_audio_input_stream(
-                AgentAudioInputConfig(
-                    encoding="pcm_s16le", sample_rate=24000, channels=1
-                )
-            )
-        for chunk in pcm.resample(target_channels=1, target_sample_rate=24000).chunks(
-            2400  # 100ms
-        ):
-            await self._audio_input_stream.send_audio_chunk(chunk.to_bytes())
+        audio_input_stream = self._audio_input_stream
+        if audio_input_stream is None:
+            audio_input_stream = self._create_audio_input_stream()
+        await audio_input_stream.send_audio_chunk(pcm.to_bytes())
 
     async def _flush_audio(self) -> None:
         if self._audio_input_stream is not None:
             await self._audio_input_stream.end_sequence()
+
+    def _create_audio_input_stream(self) -> AgentAudioInputStream:
+        audio_input_stream = self._session.create_agent_audio_input_stream(
+            AgentAudioInputConfig(
+                encoding="pcm_s16le",
+                sample_rate=self._audio_sample_rate,
+                channels=1,
+            )
+        )
+        self._audio_input_stream = audio_input_stream
+        return audio_input_stream
 
     def _subscribe_to_audio_events(self) -> None:
         @self._agent.events.subscribe
@@ -241,6 +249,8 @@ class AnamAvatarPublisher(AudioPublisher, VideoPublisher):
 
         await self._wait_connected()
         await self._wait_session_ready()
+        if self._audio_input_stream is None:
+            self._create_audio_input_stream()
         if self._audio_receiver_task is None:
             self._audio_receiver_task = asyncio.create_task(self._audio_receiver())
             self._audio_receiver_task.add_done_callback(_task_done_callback)


### PR DESCRIPTION
## Why

- Optimize Anam plugin
- We don't need to chunk the TTS audio, since Anam can handle arbitrary TTS size
- No resampling needed

## Changes

- add option for setting the audio chunk size manually (in initializer of `anam_avatar_publisher.py`)
- remove resampling of audio data