### PR TITLE
fix(gemini): unit tests no longer require GOOGLE_API_KEY

### DIFF
--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -9,9 +9,6 @@ from vision_agents.plugins.gemini import events
 from vision_agents.plugins.gemini.gemini_llm import (
     GeminiLLM,
 )
-from vision_agents.plugins.gemini.utils import (
-    convert_tools_to_provider_format,
-)
 
 
 load_dotenv()
@@ -29,57 +26,6 @@ class TestGeminiLLM:
         advanced = ["say hi"]
         messages2 = GeminiLLM._normalize_message(advanced)
         assert messages2[0].original is not None
-
-    def test_convert_tools_routes_mcp_schema_to_parameters_json_schema(self):
-        tools = [
-            {
-                "name": "search_docs",
-                "description": "Search knowledge base",
-                "parameters_schema": {
-                    "type": "object",
-                    "properties": {
-                        "query": {"type": "string", "description": "Search query"}
-                    },
-                    "required": ["query"],
-                    "additionalProperties": False,
-                    "$schema": "http://json-schema.org/draft-07/schema#",
-                },
-            }
-        ]
-
-        result = convert_tools_to_provider_format(tools)
-
-        decl = result[0]["function_declarations"][0]
-        assert "parameters" not in decl
-        schema = decl["parameters_json_schema"]
-        assert "$schema" not in schema
-        assert schema["additionalProperties"] is False
-        assert schema["required"] == ["query"]
-        assert schema["properties"]["query"]["type"] == "string"
-
-    def test_convert_tools_strips_nested_schema_meta(self):
-        tools = [
-            {
-                "name": "nested",
-                "description": "",
-                "parameters_schema": {
-                    "type": "object",
-                    "$schema": "http://json-schema.org/draft-07/schema#",
-                    "properties": {
-                        "inner": {
-                            "type": "object",
-                            "$schema": "http://json-schema.org/draft-07/schema#",
-                        }
-                    },
-                },
-            }
-        ]
-
-        schema = convert_tools_to_provider_format(tools)[0]["function_declarations"][0][
-            "parameters_json_schema"
-        ]
-        assert "$schema" not in schema
-        assert "$schema" not in schema["properties"]["inner"]
 
     @pytest.fixture
     async def llm(self):

--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -30,7 +30,7 @@ class TestGeminiLLM:
         messages2 = GeminiLLM._normalize_message(advanced)
         assert messages2[0].original is not None
 
-    async def test_convert_tools_routes_mcp_schema_to_parameters_json_schema(self):
+    def test_convert_tools_routes_mcp_schema_to_parameters_json_schema(self):
         tools = [
             {
                 "name": "search_docs",
@@ -57,7 +57,7 @@ class TestGeminiLLM:
         assert schema["required"] == ["query"]
         assert schema["properties"]["query"]["type"] == "string"
 
-    async def test_convert_tools_strips_nested_schema_meta(self):
+    def test_convert_tools_strips_nested_schema_meta(self):
         tools = [
             {
                 "name": "nested",

--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -6,7 +6,13 @@ from vision_agents.core.llm.events import (
     LLMResponseCompletedEvent,
 )
 from vision_agents.plugins.gemini import events
-from vision_agents.plugins.gemini.gemini_llm import GeminiLLM
+from vision_agents.plugins.gemini.gemini_llm import (
+    GeminiLLM,
+)
+from vision_agents.plugins.gemini.utils import (
+    convert_tools_to_provider_format,
+)
+
 
 load_dotenv()
 
@@ -24,9 +30,7 @@ class TestGeminiLLM:
         messages2 = GeminiLLM._normalize_message(advanced)
         assert messages2[0].original is not None
 
-    async def test_convert_tools_routes_mcp_schema_to_parameters_json_schema(
-        self, llm: GeminiLLM
-    ):
+    async def test_convert_tools_routes_mcp_schema_to_parameters_json_schema(self):
         tools = [
             {
                 "name": "search_docs",
@@ -43,7 +47,7 @@ class TestGeminiLLM:
             }
         ]
 
-        result = llm._convert_tools_to_provider_format(tools)
+        result = convert_tools_to_provider_format(tools)
 
         decl = result[0]["function_declarations"][0]
         assert "parameters" not in decl
@@ -53,7 +57,7 @@ class TestGeminiLLM:
         assert schema["required"] == ["query"]
         assert schema["properties"]["query"]["type"] == "string"
 
-    async def test_convert_tools_strips_nested_schema_meta(self, llm: GeminiLLM):
+    async def test_convert_tools_strips_nested_schema_meta(self):
         tools = [
             {
                 "name": "nested",
@@ -71,9 +75,9 @@ class TestGeminiLLM:
             }
         ]
 
-        schema = llm._convert_tools_to_provider_format(tools)[0][
-            "function_declarations"
-        ][0]["parameters_json_schema"]
+        schema = convert_tools_to_provider_format(tools)[0]["function_declarations"][0][
+            "parameters_json_schema"
+        ]
         assert "$schema" not in schema
         assert "$schema" not in schema["properties"]["inner"]
 

--- a/plugins/gemini/tests/test_utils.py
+++ b/plugins/gemini/tests/test_utils.py
@@ -1,0 +1,54 @@
+from vision_agents.plugins.gemini.utils import convert_tools_to_provider_format
+
+
+class TestConvertToolsToProviderFormat:
+    def test_routes_mcp_schema_to_parameters_json_schema(self):
+        tools = [
+            {
+                "name": "search_docs",
+                "description": "Search knowledge base",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"}
+                    },
+                    "required": ["query"],
+                    "additionalProperties": False,
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                },
+            }
+        ]
+
+        result = convert_tools_to_provider_format(tools)
+
+        decl = result[0]["function_declarations"][0]
+        assert "parameters" not in decl
+        schema = decl["parameters_json_schema"]
+        assert "$schema" not in schema
+        assert schema["additionalProperties"] is False
+        assert schema["required"] == ["query"]
+        assert schema["properties"]["query"]["type"] == "string"
+
+    def test_strips_nested_schema_meta(self):
+        tools = [
+            {
+                "name": "nested",
+                "description": "",
+                "parameters_schema": {
+                    "type": "object",
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "properties": {
+                        "inner": {
+                            "type": "object",
+                            "$schema": "http://json-schema.org/draft-07/schema#",
+                        }
+                    },
+                },
+            }
+        ]
+
+        schema = convert_tools_to_provider_format(tools)[0]["function_declarations"][0][
+            "parameters_json_schema"
+        ]
+        assert "$schema" not in schema
+        assert "$schema" not in schema["properties"]["inner"]

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, AsyncIterator, List, Optional
 
 from google.genai import types
 from google.genai.client import AsyncClient, Client
@@ -17,7 +17,8 @@ from vision_agents.core.llm.events import (
     LLMResponseCompletedEvent,
 )
 from vision_agents.core.llm.llm import LLM, LLMResponseEvent
-from vision_agents.core.llm.llm_types import NormalizedToolCallItem, ToolSchema
+from vision_agents.core.llm.llm_types import NormalizedToolCallItem
+from .utils import convert_tools_to_provider_format
 
 from . import events
 from .tools import GeminiTool
@@ -27,21 +28,6 @@ if TYPE_CHECKING:
 
 
 DEFAULT_MODEL = "gemini-3.1-pro-preview"
-
-
-_GEMINI_UNSUPPORTED_SCHEMA_KEYS = frozenset({"$schema"})
-
-
-def _strip_unsupported_schema_keys(node: Any) -> Any:
-    if isinstance(node, dict):
-        return {
-            k: _strip_unsupported_schema_keys(v)
-            for k, v in node.items()
-            if k not in _GEMINI_UNSUPPORTED_SCHEMA_KEYS
-        }
-    if isinstance(node, list):
-        return [_strip_unsupported_schema_keys(item) for item in node]
-    return node
 
 
 class GeminiLLM(LLM):
@@ -211,7 +197,7 @@ class GeminiLLM(LLM):
         # Add tools if available - Gemini uses GenerateContentConfig
         tools_spec = self.get_available_functions()
         if tools_spec:
-            conv_tools = self._convert_tools_to_provider_format(tools_spec)
+            conv_tools = convert_tools_to_provider_format(tools_spec)
             cfg = kwargs.get("config")
             if not isinstance(cfg, GenerateContentConfig):
                 cfg = self._build_config()
@@ -468,31 +454,6 @@ class GeminiLLM(LLM):
                         if part.text:
                             texts.append(part.text)
         return "".join(texts)
-
-    def _convert_tools_to_provider_format(
-        self, tools: List[ToolSchema]
-    ) -> List[Dict[str, Any]]:
-        """
-        Convert ToolSchema objects to Gemini format.
-        Args:
-            tools: List of ToolSchema objects
-        Returns:
-            List of tools in Gemini format
-        """
-        function_declarations = []
-        for tool in tools:
-            function_declarations.append(
-                {
-                    "name": tool["name"],
-                    "description": tool.get("description", ""),
-                    "parameters_json_schema": _strip_unsupported_schema_keys(
-                        tool["parameters_schema"]
-                    ),
-                }
-            )
-
-        # Return as dict with function_declarations (SDK accepts dicts)
-        return [{"function_declarations": function_declarations}]
 
     def _extract_tool_calls_from_response(
         self, response: Any

--- a/plugins/gemini/vision_agents/plugins/gemini/utils.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/utils.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict, List
+
+from vision_agents.core.llm.llm_types import ToolSchema
+
+
+_GEMINI_UNSUPPORTED_SCHEMA_KEYS = frozenset({"$schema"})
+
+
+def _strip_unsupported_schema_keys(node: Any) -> Any:
+    if isinstance(node, dict):
+        return {
+            k: _strip_unsupported_schema_keys(v)
+            for k, v in node.items()
+            if k not in _GEMINI_UNSUPPORTED_SCHEMA_KEYS
+        }
+    if isinstance(node, list):
+        return [_strip_unsupported_schema_keys(item) for item in node]
+    return node
+
+
+def convert_tools_to_provider_format(tools: List[ToolSchema]) -> List[Dict[str, Any]]:
+    """
+    Convert ToolSchema objects to Gemini format.
+    Args:
+        tools: List of ToolSchema objects
+    Returns:
+        List of tools in Gemini format
+    """
+    function_declarations = []
+    for tool in tools:
+        function_declarations.append(
+            {
+                "name": tool["name"],
+                "description": tool.get("description", ""),
+                "parameters_json_schema": _strip_unsupported_schema_keys(
+                    tool["parameters_schema"]
+                ),
+            }
+        )
+
+    # Return as dict with function_declarations (SDK accepts dicts)
+    return [{"function_declarations": function_declarations}]


### PR DESCRIPTION
## Why

CI for #516 was failing because `plugins/gemini/tests/test_gemini_llm.py::TestGeminiLLM::test_convert_tools_routes_mcp_schema_to_parameters_json_schema` and `test_convert_tools_strips_nested_schema_meta` errored at fixture setup with `ValueError: No API key was provided`. These are unit tests for a pure schema-conversion function, but they were sharing the integration `llm` fixture which constructs `GeminiLLM()` and therefore `Client(api_key=...)`. CI sets `GOOGLE_API_KEY` to an empty string, which overrides the `load_dotenv()` lookup, so the client constructor fails. Locally the tests passed because `load_dotenv()` walks up to `~/.env` and picks up the developer's key — that masking is what made this look like CI-only flakiness.

## Changes

- Move `convert_tools_to_provider_format` (and the private `_strip_unsupported_schema_keys` helper) from `gemini_llm.py` into a new `utils.py` module so the conversion logic is decoupled from the LLM class.
- Update `GeminiLLM` to call the function from `utils`. The integration `llm` fixture is unchanged.
- Update the two unit tests to call `convert_tools_to_provider_format` directly, removing their dependency on the fixture and on a Gemini API key.