### PR TITLE
refactor(agents): remove call_id validator

### DIFF
--- a/agents-core/vision_agents/core/agents/agent_launcher.py
+++ b/agents-core/vision_agents/core/agents/agent_launcher.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial
@@ -16,7 +15,6 @@ from vision_agents.core.utils.utils import await_or_run, cancel_and_wait
 from vision_agents.core.warmup import Warmable, WarmupCache
 
 from .exceptions import (
-    InvalidCallId,
     MaxConcurrentSessionsExceeded,
     MaxSessionsPerCallExceeded,
 )
@@ -26,8 +24,6 @@ if TYPE_CHECKING:
     from .agents import Agent
 
 logger = logging.getLogger(__name__)
-
-_VALID_CALL_ID = re.compile(r"^[a-z0-9_-]+$")
 
 
 @dataclass
@@ -294,17 +290,11 @@ class AgentLauncher:
             An AgentSession object representing the new session.
 
         Raises:
-            InvalidCallId: If the call_id contains invalid characters.
             MaxConcurrentSessionsExceeded: If the maximum number of concurrent
                 sessions has been reached.
             MaxSessionsPerCallExceeded: If the maximum number of sessions for
                 this call_id has been reached.
         """
-        if not _VALID_CALL_ID.fullmatch(call_id):
-            raise InvalidCallId(
-                f"Invalid call_id {call_id!r}: must contain only a-z, 0-9, _ and -"
-            )
-
         async with self._start_lock:
             if (
                 self._max_concurrent_sessions

--- a/agents-core/vision_agents/core/agents/exceptions.py
+++ b/agents-core/vision_agents/core/agents/exceptions.py
@@ -6,7 +6,3 @@ class MaxConcurrentSessionsExceeded(SessionLimitExceeded): ...
 
 
 class MaxSessionsPerCallExceeded(SessionLimitExceeded): ...
-
-
-class InvalidCallId(Exception):
-    pass

--- a/agents-core/vision_agents/core/runner/http/api.py
+++ b/agents-core/vision_agents/core/runner/http/api.py
@@ -6,7 +6,6 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.responses import Response
 from vision_agents.core import AgentLauncher
 from vision_agents.core.agents.exceptions import (
-    InvalidCallId,
     MaxConcurrentSessionsExceeded,
     MaxSessionsPerCallExceeded,
 )
@@ -56,16 +55,6 @@ router = APIRouter()
             "description": "Session created successfully",
             "model": StartSessionResponse,
         },
-        400: {
-            "description": "Invalid call_id",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "detail": "Invalid call_id 'bad!id': must contain only a-z, 0-9, _ and -",
-                    }
-                }
-            },
-        },
         429: {
             "description": "Session limits exceeded",
             "content": {
@@ -101,11 +90,6 @@ async def start_session(
         session = await launcher.start_session(
             call_id=call_id, call_type=request.call_type
         )
-    except InvalidCallId as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid call_id: must contain only a-z, 0-9, _ and -",
-        ) from e
     except MaxConcurrentSessionsExceeded as e:
         raise HTTPException(
             status_code=429,

--- a/tests/test_agents/test_agent_launcher.py
+++ b/tests/test_agents/test_agent_launcher.py
@@ -8,7 +8,6 @@ import redis.asyncio as redis
 from testcontainers.redis import RedisContainer
 from vision_agents.core import Agent, AgentLauncher, User
 from vision_agents.core.agents.exceptions import (
-    InvalidCallId,
     MaxConcurrentSessionsExceeded,
     MaxSessionsPerCallExceeded,
 )
@@ -449,27 +448,6 @@ class TestAgentLauncher:
                 join_call=join_call_noop,
                 max_sessions_per_call=-1,
             )
-
-    @pytest.mark.parametrize(
-        "call_id",
-        ["UPPER", "has space", "a/b", "", "café", "call@id", "a.b"],
-    )
-    async def test_invalid_call_id_rejected(self, stream_edge_mock, call_id):
-        async def create_agent(**kwargs) -> Agent:
-            return Agent(
-                llm=DummyLLM(),
-                tts=DummyTTS(),
-                edge=stream_edge_mock,
-                agent_user=User(name="test"),
-            )
-
-        launcher = AgentLauncher(
-            create_agent=create_agent,
-            join_call=join_call_noop,
-        )
-        async with launcher:
-            with pytest.raises(InvalidCallId):
-                await launcher.start_session(call_id=call_id)
 
     async def test_max_concurrent_agents_exceeded(self, stream_edge_mock):
         async def create_agent(**kwargs) -> Agent:


### PR DESCRIPTION
## Why

Different transports use different `call_id` formats. The hardcoded `[a-z0-9_-]+` regex was an ad-hoc restriction in framework core. Validation belongs in the transport implementation.

## Changes

- Remove `_VALID_CALL_ID` regex and the validation block in `AgentLauncher.start_session`.
- Delete `agents/call_id.py` (helpers no longer needed).
- Delete `InvalidCallId` exception and its handlers in the HTTP API and OpenAPI schema.
- Remove the parametrized validator tests.