### PR TITLE
Inworld TTS: switch from AV/HTTP to bidirectional WebSocket streaming

### DIFF
--- a/plugins/inworld/pyproject.toml
+++ b/plugins/inworld/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 dependencies = [
     "vision-agents",
     "httpx>=0.28.1",
-    "av>=10.0.0",
+    "websockets",
     "aiortc>=1.9",
     "openai[realtime]>=2.26.0,<3",
 ]

--- a/plugins/inworld/pyproject.toml
+++ b/plugins/inworld/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 dependencies = [
     "vision-agents",
     "httpx>=0.28.1",
-    "websockets",
+    "websockets>=14.0",
     "aiortc>=1.9",
     "openai[realtime]>=2.26.0,<3",
 ]

--- a/plugins/inworld/vision_agents/plugins/inworld/tts.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/tts.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import io
 import json
 import logging
 import os
@@ -7,6 +8,7 @@ import uuid
 from importlib.metadata import PackageNotFoundError, version
 from typing import AsyncIterator, Iterator, Literal
 
+import av
 import websockets
 import websockets.exceptions
 from getstream.video.rtc.track_util import AudioFormat, PcmData
@@ -25,39 +27,34 @@ except PackageNotFoundError:
 USER_AGENT = f"vision-agents-plugins-inworld/{_pkg_version}"
 
 
-def _extract_wav_pcm(data: bytes) -> tuple[int | None, bytes]:
-    """Extract sample rate and PCM payload from a WAV chunk.
-
-    Falls back to the full payload when the input is not a WAV container.
-    """
+def _decode_audio(data: bytes, target_sample_rate: int) -> PcmData | None:
+    """Decode an audio chunk (WAV or raw PCM) into a PcmData object."""
     if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
-        return None, data
+        if len(data) < 2:
+            return None
+        return PcmData.from_bytes(
+            data, sample_rate=target_sample_rate, channels=1, format=AudioFormat.S16
+        )
 
-    offset = 12
-    sample_rate: int | None = None
-    data_payload: bytes | None = None
+    container = av.open(io.BytesIO(data), format="wav", mode="r")
+    try:
+        frames = list(container.decode(audio=0))
+    finally:
+        container.close()
 
-    while offset + 8 <= len(data):
-        chunk_id = data[offset : offset + 4]
-        chunk_size = int.from_bytes(data[offset + 4 : offset + 8], byteorder="little")
-        chunk_start = offset + 8
-        chunk_end = min(chunk_start + chunk_size, len(data))
+    if not frames:
+        return None
 
-        if chunk_id == b"fmt " and chunk_size >= 16 and chunk_start + 8 <= len(data):
-            # WAV fmt layout: audio_format(2), channels(2), sample_rate(4), ...
-            sample_rate = int.from_bytes(
-                data[chunk_start + 4 : chunk_start + 8], byteorder="little"
-            )
-        elif chunk_id == b"data":
-            data_payload = data[chunk_start:chunk_end]
-            break
+    result = PcmData.from_av_frame(frames[0])
+    for frame in frames[1:]:
+        result = result.append(PcmData.from_av_frame(frame))
 
-        # Chunks are padded to even byte boundaries.
-        offset = chunk_end + (chunk_size % 2)
+    if result.sample_rate != target_sample_rate:
+        result = result.resample(
+            target_sample_rate=target_sample_rate, target_channels=1
+        ).to_int16()
 
-    if data_payload is None:
-        return sample_rate, data
-    return sample_rate, data_payload
+    return result
 
 
 class TTS(tts.TTS):
@@ -142,6 +139,7 @@ class TTS(tts.TTS):
         except (websockets.exceptions.WebSocketException, OSError):
             logger.warning("Inworld TTS websocket dropped; reconnecting")
             await self._reset_connection()
+            self._active_context_id = context_id
             await self._send_text_and_flush(text, context_id)
 
         return self._receive_audio(context_id, generation)
@@ -188,7 +186,6 @@ class TTS(tts.TTS):
     ) -> AsyncIterator[PcmData]:
         websocket = await self._ensure_connection()
         should_close_context = True
-        carry = b""
 
         try:
             while True:
@@ -232,26 +229,9 @@ class TTS(tts.TTS):
                 audio_b64 = audio_chunk.get("audioContent")
                 if audio_b64:
                     decoded = base64.b64decode(audio_b64)
-                    source_rate, pcm_bytes = _extract_wav_pcm(decoded)
-                    if pcm_bytes:
-                        carry += pcm_bytes
-                        usable = len(carry) - (len(carry) % 2)
-                        if usable > 0:
-                            chunk_bytes = carry[:usable]
-                            carry = carry[usable:]
-
-                            pcm = PcmData.from_bytes(
-                                chunk_bytes,
-                                sample_rate=source_rate or self._sample_rate,
-                                channels=1,
-                                format=AudioFormat.S16,
-                            )
-                            if source_rate and source_rate != self._sample_rate:
-                                pcm = pcm.resample(
-                                    target_sample_rate=self._sample_rate,
-                                    target_channels=1,
-                                ).to_int16()
-                            yield pcm
+                    pcm = _decode_audio(decoded, self._sample_rate)
+                    if pcm:
+                        yield pcm
 
                 if "contextClosed" in result:
                     should_close_context = False
@@ -260,12 +240,6 @@ class TTS(tts.TTS):
                 if "flushCompleted" in result:
                     break
         finally:
-            if carry:
-                logger.debug(
-                    "Dropping %d trailing unaligned PCM bytes for context %s",
-                    len(carry),
-                    context_id,
-                )
             if self._active_context_id == context_id:
                 self._active_context_id = None
             if should_close_context:
@@ -316,8 +290,21 @@ class TTS(tts.TTS):
         )
 
     async def _ensure_connection(self) -> websockets.ClientConnection:
-        if self._websocket is not None:
+        if (
+            self._websocket is not None
+            and self._websocket.state is websockets.State.OPEN
+        ):
             return self._websocket
+
+        if self._websocket is not None:
+            try:
+                await self._websocket.close()
+            except (websockets.exceptions.WebSocketException, OSError):
+                pass
+            self._websocket = None
+
+        if self._keepalive_task is not None and self._keepalive_task.done():
+            self._keepalive_task = None
 
         request_id = str(uuid.uuid4())
         self._websocket = await websockets.connect(
@@ -355,7 +342,8 @@ class TTS(tts.TTS):
         if websocket is None:
             return
 
-        while True:
+        deadline = asyncio.get_running_loop().time() + 0.5
+        while asyncio.get_running_loop().time() < deadline:
             try:
                 await asyncio.wait_for(websocket.recv(), timeout=0.05)
             except TimeoutError:
@@ -371,6 +359,8 @@ class TTS(tts.TTS):
             if websocket is None:
                 return
             if websocket.state is not websockets.State.OPEN:
+                if self._websocket is websocket:
+                    self._websocket = None
                 return
             payload: dict[str, object] = {"send_text": {"text": ""}}
             if self._active_context_id:
@@ -378,5 +368,10 @@ class TTS(tts.TTS):
             try:
                 await websocket.send(json.dumps(payload))
             except (websockets.exceptions.WebSocketException, OSError):
-                await self._reset_connection()
+                if self._websocket is websocket:
+                    self._websocket = None
+                try:
+                    await websocket.close()
+                except (websockets.exceptions.WebSocketException, OSError):
+                    pass
                 return

--- a/plugins/inworld/vision_agents/plugins/inworld/tts.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/tts.py
@@ -215,7 +215,9 @@ class TTS(tts.TTS):
                 if status.get("code", 0) != 0:
                     error_message = status.get("message", "Unknown Inworld error")
                     if "max contexts limit reached" in error_message.lower():
-                        logger.warning("Inworld context limit reached; resetting websocket")
+                        logger.warning(
+                            "Inworld context limit reached; resetting websocket"
+                        )
                         await self._reset_connection()
                     raise RuntimeError(f"Inworld TTS websocket error: {error_message}")
 

--- a/plugins/inworld/vision_agents/plugins/inworld/tts.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/tts.py
@@ -1,20 +1,21 @@
+import asyncio
 import base64
-import io
 import json
 import logging
 import os
 import uuid
 from importlib.metadata import PackageNotFoundError, version
-from typing import AsyncIterator, Literal, Optional
+from typing import AsyncIterator, Iterator, Literal
 
-import av
-import httpx
-from getstream.video.rtc.track_util import PcmData
+import websockets
+import websockets.exceptions
+from getstream.video.rtc.track_util import AudioFormat, PcmData
 from vision_agents.core import tts
 
 logger = logging.getLogger(__name__)
 
-INWORLD_API_BASE = "https://api.inworld.ai"
+INWORLD_WS_URL = "wss://api.inworld.ai/tts/v1/voice:streamBidirectional"
+KEEPALIVE_INTERVAL_SECONDS = 60
 
 try:
     _pkg_version = version("vision-agents-plugins-inworld")
@@ -24,15 +25,49 @@ except PackageNotFoundError:
 USER_AGENT = f"vision-agents-plugins-inworld/{_pkg_version}"
 
 
+def _extract_wav_pcm(data: bytes) -> tuple[int | None, bytes]:
+    """Extract sample rate and PCM payload from a WAV chunk.
+
+    Falls back to the full payload when the input is not a WAV container.
+    """
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        return None, data
+
+    offset = 12
+    sample_rate: int | None = None
+    data_payload: bytes | None = None
+
+    while offset + 8 <= len(data):
+        chunk_id = data[offset : offset + 4]
+        chunk_size = int.from_bytes(data[offset + 4 : offset + 8], byteorder="little")
+        chunk_start = offset + 8
+        chunk_end = min(chunk_start + chunk_size, len(data))
+
+        if chunk_id == b"fmt " and chunk_size >= 16 and chunk_start + 8 <= len(data):
+            # WAV fmt layout: audio_format(2), channels(2), sample_rate(4), ...
+            sample_rate = int.from_bytes(
+                data[chunk_start + 4 : chunk_start + 8], byteorder="little"
+            )
+        elif chunk_id == b"data":
+            data_payload = data[chunk_start:chunk_end]
+            break
+
+        # Chunks are padded to even byte boundaries.
+        offset = chunk_end + (chunk_size % 2)
+
+    if data_payload is None:
+        return sample_rate, data
+    return sample_rate, data_payload
+
+
 class TTS(tts.TTS):
-    """
-    Inworld AI Text-to-Speech implementation.
-    Inworld AI provides high-quality text-to-speech synthesis with streaming support.
-    """
+    """Inworld AI Text-to-Speech plugin using bidirectional WebSocket streaming."""
+
+    streaming = True
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         voice_id: str = "Sarah",
         model_id: Literal[
             "inworld-tts-1.5-max",
@@ -41,18 +76,25 @@ class TTS(tts.TTS):
             "inworld-tts-1-max",
             "inworld-tts-2",
         ] = "inworld-tts-2",
+        sample_rate: int = 16000,
         temperature: float = 1.1,
+        speaking_rate: float | None = None,
+        auto_mode: bool = True,
+        apply_text_normalization: Literal["ON", "OFF"] | None = None,
+        ws_url: str = INWORLD_WS_URL,
     ):
-        """
-        Initialize the Inworld AI TTS service.
+        """Initialize the Inworld AI WebSocket TTS service.
+
         Args:
-            api_key: Inworld AI API key. If not provided, the INWORLD_API_KEY
-                    environment variable will be used.
-            voice_id: The voice ID to use for synthesis (default: "Sarah").
-            model_id: The model ID to use for synthesis. Options: "inworld-tts-2",
-                     "inworld-tts-1.5-max", "inworld-tts-1.5-mini" (default: "inworld-tts-2").
-            temperature: Determines the degree of randomness when sampling audio tokens.
-                        Accepts values between 0 and 2. Default: 1.1.
+            api_key: Inworld AI API key – falls back to ``INWORLD_API_KEY`` env var.
+            voice_id: The voice ID to use for synthesis.
+            model_id: The model to use for synthesis.
+            sample_rate: Desired PCM sample rate in Hz.
+            temperature: Randomness when sampling audio tokens (0–2).
+            speaking_rate: Speech speed multiplier (0.5–1.5). ``None`` uses the server default.
+            auto_mode: Whether Inworld should decide optimal flush behavior.
+            apply_text_normalization: Optional text normalization behavior.
+            ws_url: Inworld bidirectional WebSocket endpoint.
         """
         super().__init__(provider_name="inworld")
 
@@ -62,132 +104,277 @@ class TTS(tts.TTS):
                 "INWORLD_API_KEY environment variable must be set or api_key must be provided"
             )
 
-        self.api_key = api_key
-        self.voice_id = voice_id
-        self.model_id = model_id
-        self.temperature = temperature
-        self.base_url = INWORLD_API_BASE
-        self.client = httpx.AsyncClient(timeout=60.0)
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._model_id = model_id
+        self._sample_rate = sample_rate
+        self._temperature = temperature
+        self._speaking_rate = speaking_rate
+        self._auto_mode = auto_mode
+        self._apply_text_normalization = apply_text_normalization
+        self._ws_url = ws_url
 
-    async def stream_audio(self, text: str, *_, **__) -> AsyncIterator[PcmData]:
-        """
-        Convert text to speech using Inworld AI API.
-        Args:
-            text: The text to convert to speech (max 2,000 characters).
-        Returns:
-            An async iterator of audio chunks as PcmData objects.
-        """
-        url = f"{self.base_url}/tts/v1/voice:stream"
+        self._websocket: websockets.ClientConnection | None = None
+        self._generation = 0
+        self._stop_event = asyncio.Event()
+        self._active_context_id: str | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
 
-        request_id = str(uuid.uuid4())
-        headers = {
-            "Authorization": f"Basic {self.api_key}",
-            "Content-Type": "application/json",
-            "X-User-Agent": USER_AGENT,
-            "X-Request-Id": request_id,
-        }
+    async def start(self) -> None:
+        """Open the persistent Inworld WebSocket connection."""
+        await self._ensure_connection()
 
-        payload = {
-            "text": text,
-            "voiceId": self.voice_id,
-            "modelId": self.model_id,
-            "audioConfig": {
-                "temperature": self.temperature,
-                "audioEncoding": "LINEAR16",
-            },
-        }
+    async def stream_audio(
+        self, text: str, *_, **__
+    ) -> PcmData | Iterator[PcmData] | AsyncIterator[PcmData]:
+        """Convert text to speech over Inworld bidirectional WebSocket."""
+        if self._stop_event.is_set():
+            await self._drain()
+            self._stop_event.clear()
 
-        async def _stream_audio() -> AsyncIterator[PcmData]:
-            try:
-                async with self.client.stream(
-                    "POST", url, headers=headers, json=payload
-                ) as response:
-                    async for pcm in self._process_response(response):
-                        yield pcm
-            except httpx.HTTPStatusError as e:
-                logger.error(
-                    "Inworld AI API HTTP error: %s - %s (request_id=%s)",
-                    e.response.status_code,
-                    e.response.text,
-                    request_id,
-                )
-                raise
-            except Exception:
-                logger.exception(
-                    "Error streaming audio from Inworld AI (request_id=%s)",
-                    request_id,
-                )
-                raise
+        context_id = str(uuid.uuid4())
+        self._active_context_id = context_id
+        self._generation += 1
+        generation = self._generation
 
-        # Return the async generator
-        return _stream_audio()
+        try:
+            await self._send_text_and_flush(text, context_id)
+        except (websockets.exceptions.WebSocketException, OSError):
+            logger.warning("Inworld TTS websocket dropped; reconnecting")
+            await self._reset_connection()
+            await self._send_text_and_flush(text, context_id)
 
-    async def _process_response(
-        self, response: httpx.Response
-    ) -> AsyncIterator[PcmData]:
-        # Check status before processing streaming response
-        if response.status_code >= 400:
-            error_text = await response.aread()
-            error_msg = error_text.decode() if error_text else "Unknown error"
-            logger.error(
-                "Inworld AI API HTTP error: %s - %s",
-                response.status_code,
-                error_msg,
-            )
-            raise httpx.HTTPStatusError(
-                f"HTTP {response.status_code}: {error_msg}",
-                request=response.request,
-                response=response,
-            )
-
-        async for line in response.aiter_lines():
-            if not line.strip():
-                continue
-
-            try:
-                data = json.loads(line)
-                if "error" in data:
-                    error_msg = data["error"].get("message", "Unknown error")
-                    logger.error("Inworld AI API error: %s", error_msg)
-                    continue
-
-                if "result" in data and "audioContent" in data["result"]:
-                    wav_bytes = base64.b64decode(data["result"]["audioContent"])
-
-                    container = av.open(io.BytesIO(wav_bytes))
-                    assert isinstance(container, av.container.InputContainer)
-                    with container:
-                        audio_stream = container.streams.audio[0]
-                        pcm: Optional[PcmData] = None
-                        for frame in container.decode(audio_stream):
-                            frame_pcm = PcmData.from_av_frame(frame)
-                            if pcm is None:
-                                pcm = frame_pcm
-                            else:
-                                pcm.append(frame_pcm)
-
-                        if pcm:
-                            pcm = pcm.resample(
-                                target_sample_rate=pcm.sample_rate,
-                                target_channels=1,
-                            ).to_int16()
-                            yield pcm
-            except json.JSONDecodeError as e:
-                logger.warning("Failed to parse JSON line: %s", e)
-                continue
-            except Exception as e:
-                logger.warning("Error processing audio chunk: %s", e)
-                continue
+        return self._receive_audio(context_id, generation)
 
     async def stop_audio(self) -> None:
-        """
-        Clears the queue and stops playing audio.
-        This method can be used manually or under the hood in response to turn events.
-        Returns:
-            None
-        """
-        logger.info("🎤 Inworld AI TTS stop requested (no-op)")
+        """Stop current synthesis by closing the active context."""
+        self._generation += 1
+        self._stop_event.set()
+
+        if self._active_context_id and self._websocket is not None:
+            try:
+                await self._send_close_context(self._active_context_id)
+            except (websockets.exceptions.WebSocketException, OSError):
+                await self._reset_connection()
+            finally:
+                self._active_context_id = None
 
     async def close(self) -> None:
-        if self.client:
-            await self.client.aclose()
+        await self._reset_connection()
+        await super().close()
+
+    async def _send_text_and_flush(self, text: str, context_id: str) -> None:
+        websocket = await self._ensure_connection()
+        await self._send_create_context(context_id)
+        await websocket.send(
+            json.dumps(
+                {
+                    "send_text": {"text": text},
+                    "contextId": context_id,
+                }
+            )
+        )
+        await websocket.send(
+            json.dumps(
+                {
+                    "flush_context": {},
+                    "contextId": context_id,
+                }
+            )
+        )
+
+    async def _receive_audio(
+        self, context_id: str, generation: int
+    ) -> AsyncIterator[PcmData]:
+        websocket = await self._ensure_connection()
+        should_close_context = True
+        carry = b""
+
+        try:
+            while True:
+                if self._stop_event.is_set() or self._generation != generation:
+                    break
+
+                try:
+                    message = await websocket.recv()
+                except (websockets.exceptions.ConnectionClosed, OSError):
+                    await self._reset_connection()
+                    raise
+
+                if not isinstance(message, str):
+                    continue
+
+                try:
+                    data = json.loads(message)
+                except json.JSONDecodeError:
+                    logger.warning("Skipping non-JSON Inworld TTS websocket message")
+                    continue
+
+                result = data.get("result", {})
+                status = result.get("status", {})
+                if status.get("code", 0) != 0:
+                    error_message = status.get("message", "Unknown Inworld error")
+                    if "max contexts limit reached" in error_message.lower():
+                        logger.warning("Inworld context limit reached; resetting websocket")
+                        await self._reset_connection()
+                    raise RuntimeError(f"Inworld TTS websocket error: {error_message}")
+
+                if "error" in data:
+                    raise RuntimeError(f"Inworld TTS websocket error: {data['error']}")
+
+                msg_context_id = result.get("contextId") or result.get("context_id")
+                if msg_context_id and msg_context_id != context_id:
+                    continue
+
+                audio_chunk = result.get("audioChunk", {})
+                audio_b64 = audio_chunk.get("audioContent")
+                if audio_b64:
+                    decoded = base64.b64decode(audio_b64)
+                    source_rate, pcm_bytes = _extract_wav_pcm(decoded)
+                    if pcm_bytes:
+                        carry += pcm_bytes
+                        usable = len(carry) - (len(carry) % 2)
+                        if usable > 0:
+                            chunk_bytes = carry[:usable]
+                            carry = carry[usable:]
+
+                            pcm = PcmData.from_bytes(
+                                chunk_bytes,
+                                sample_rate=source_rate or self._sample_rate,
+                                channels=1,
+                                format=AudioFormat.S16,
+                            )
+                            if source_rate and source_rate != self._sample_rate:
+                                pcm = pcm.resample(
+                                    target_sample_rate=self._sample_rate,
+                                    target_channels=1,
+                                ).to_int16()
+                            yield pcm
+
+                if "contextClosed" in result:
+                    should_close_context = False
+                    break
+
+                if "flushCompleted" in result:
+                    break
+        finally:
+            if carry:
+                logger.debug(
+                    "Dropping %d trailing unaligned PCM bytes for context %s",
+                    len(carry),
+                    context_id,
+                )
+            if self._active_context_id == context_id:
+                self._active_context_id = None
+            if should_close_context:
+                try:
+                    await self._send_close_context(context_id)
+                except (websockets.exceptions.WebSocketException, OSError):
+                    await self._reset_connection()
+
+    async def _send_create_context(self, context_id: str) -> None:
+        websocket = await self._ensure_connection()
+        audio_config: dict[str, object] = {
+            "audioEncoding": "LINEAR16",
+            "sampleRateHertz": self._sample_rate,
+        }
+        if self._speaking_rate is not None:
+            audio_config["speakingRate"] = self._speaking_rate
+
+        create_config: dict[str, object] = {
+            "voiceId": self._voice_id,
+            "modelId": self._model_id,
+            "audioConfig": audio_config,
+            "temperature": self._temperature,
+            "autoMode": self._auto_mode,
+            "timestampType": "TIMESTAMP_TYPE_UNSPECIFIED",
+        }
+        if self._apply_text_normalization is not None:
+            create_config["applyTextNormalization"] = self._apply_text_normalization
+
+        await websocket.send(
+            json.dumps(
+                {
+                    "create": create_config,
+                    "contextId": context_id,
+                }
+            )
+        )
+
+    async def _send_close_context(self, context_id: str) -> None:
+        if self._websocket is None:
+            return
+        await self._websocket.send(
+            json.dumps(
+                {
+                    "close_context": {},
+                    "contextId": context_id,
+                }
+            )
+        )
+
+    async def _ensure_connection(self) -> websockets.ClientConnection:
+        if self._websocket is not None:
+            return self._websocket
+
+        request_id = str(uuid.uuid4())
+        self._websocket = await websockets.connect(
+            self._ws_url,
+            additional_headers={
+                "Authorization": f"Basic {self._api_key}",
+                "X-User-Agent": USER_AGENT,
+                "X-Request-Id": request_id,
+            },
+        )
+        if self._keepalive_task is None:
+            self._keepalive_task = asyncio.create_task(self._keepalive_loop())
+        return self._websocket
+
+    async def _reset_connection(self) -> None:
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
+            except asyncio.CancelledError:
+                pass
+            self._keepalive_task = None
+
+        if self._websocket is not None:
+            try:
+                await self._websocket.close()
+            finally:
+                self._websocket = None
+
+        self._active_context_id = None
+        self._stop_event.clear()
+
+    async def _drain(self) -> None:
+        websocket = self._websocket
+        if websocket is None:
+            return
+
+        while True:
+            try:
+                await asyncio.wait_for(websocket.recv(), timeout=0.05)
+            except TimeoutError:
+                break
+            except (websockets.exceptions.ConnectionClosed, OSError):
+                await self._reset_connection()
+                break
+
+    async def _keepalive_loop(self) -> None:
+        while True:
+            await asyncio.sleep(KEEPALIVE_INTERVAL_SECONDS)
+            websocket = self._websocket
+            if websocket is None:
+                return
+            if websocket.state is not websockets.State.OPEN:
+                return
+            payload: dict[str, object] = {"send_text": {"text": ""}}
+            if self._active_context_id:
+                payload["contextId"] = self._active_context_id
+            try:
+                await websocket.send(json.dumps(payload))
+            except (websockets.exceptions.WebSocketException, OSError):
+                await self._reset_connection()
+                return

--- a/uv.lock
+++ b/uv.lock
@@ -7760,7 +7760,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai", extras = ["realtime"], specifier = ">=2.26.0,<3" },
     { name = "vision-agents", editable = "agents-core" },
-    { name = "websockets" },
+    { name = "websockets", specifier = ">=14.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -7742,10 +7742,10 @@ name = "vision-agents-plugins-inworld"
 source = { editable = "plugins/inworld" }
 dependencies = [
     { name = "aiortc" },
-    { name = "av" },
     { name = "httpx" },
     { name = "openai", extra = ["realtime"] },
     { name = "vision-agents" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -7757,10 +7757,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiortc", specifier = ">=1.9" },
-    { name = "av", specifier = ">=10.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai", extras = ["realtime"], specifier = ">=2.26.0,<3" },
     { name = "vision-agents", editable = "agents-core" },
+    { name = "websockets" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Why

The Inworld TTS plugin previously used an httpx-based HTTP NDJSON stream and PyAV for decoding WAV audio. This switches to Inworld's bidirectional WebSocket endpoint (`streamBidirectional`), which enables persistent connections with keepalive, context-based session management, and proper stop/interrupt support. The `av` dependency is replaced with `websockets`.

## Changes

- Replace httpx HTTP streaming with a persistent `websockets` connection to `wss://api.inworld.ai/tts/v1/voice:streamBidirectional`
- Implement context lifecycle: create, send text, flush, close, and keepalive
- Add generation-based cancellation and `stop_audio` support via context close
- Parse WAV headers manually instead of using PyAV (`_extract_wav_pcm`)
- Swap `av>=10.0.0` dependency for `websockets` in `pyproject.toml`

Made with [Cursor](https://cursor.com)