### PR TITLE
openai.Realtime: update default model to gpt-realtime-2

### DIFF
--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -69,7 +69,7 @@ class Realtime(realtime.Realtime):
 
     def __init__(
         self,
-        model: str = "gpt-realtime-1.5",
+        model: str = "gpt-realtime-2",
         api_key: Optional[str] = None,
         voice: str = "marin",
         client: Optional[AsyncOpenAI] = None,


### PR DESCRIPTION
This PR update the default `openai.Realtime` model to `gpt-realtime-2`.