### PR TITLE
Bump getstream version to v3.3.2

### DIFF
--- a/agents-core/pyproject.toml
+++ b/agents-core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "getstream[webrtc,telemetry]>=3.3.1,<4",
+    "getstream[webrtc,telemetry]>=3.3.2,<4",
     "aiortc>=1.14.0,<1.15.0",
     "python-dotenv>=1.1.1",
     "pillow>=10.4.0",

--- a/plugins/getstream/pyproject.toml
+++ b/plugins/getstream/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",
-    "getstream[webrtc,telemetry]>=3.3.1,<4",
+    "getstream[webrtc,telemetry]>=3.3.2,<4",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1896,7 +1896,7 @@ wheels = [
 
 [[package]]
 name = "getstream"
-version = "3.3.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dataclasses-json" },
@@ -1911,9 +1911,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "twirp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bd/b3218b1524fc120d2a499fba06165b39cebea8a1c446840eadab32aa4a77/getstream-3.3.1.tar.gz", hash = "sha256:131bedd48f63bbb74ae7d3250a154ad48c312ef22ad6f984cb7d2e8b835179db", size = 526077, upload-time = "2026-05-08T16:03:52.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/8b/ac4dfb7840b0821baf0509e2ddfcfc32b64ae7967def05df05271ef04788/getstream-3.3.2.tar.gz", hash = "sha256:b8df0ddf976452caa063a8ed4d617220bdb39483e0ea3b0a6eb6faaeff609db7", size = 527378, upload-time = "2026-05-12T15:45:01.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/8f/150e94f6d2701cbb43e499c109d10e6377525a280125213db515bda4055e/getstream-3.3.1-py3-none-any.whl", hash = "sha256:7e32a8cd7aa53354cacf648240fd0e7dfa909574d9f75f6de7843fe8d85a7c76", size = 334022, upload-time = "2026-05-08T16:03:50.722Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/49/e90aa9e4880308c842a3d4f463f3f150ab48abe056b857ebce055e540f32/getstream-3.3.2-py3-none-any.whl", hash = "sha256:2d312f601254ee07b5e82e40bef8c25e81c4d3db744a8faed1e49e97b4df739a", size = 335271, upload-time = "2026-05-12T15:45:02.823Z" },
 ]
 
 [package.optional-dependencies]
@@ -7236,7 +7236,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'dev'" },
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "fastapi", specifier = ">=0.135.1" },
-    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.1,<4" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.2,<4" },
     { name = "mcp", specifier = ">=1.23.3,<2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -7644,7 +7644,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.1,<4" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.2,<4" },
     { name = "vision-agents", editable = "agents-core" },
 ]
 


### PR DESCRIPTION
## Why

`getstream` 3.3.2 ships a handful of rtc reliability fixes that affect long-running agent sessions:

- auto-reconnect on signaling-WebSocket loss (transient TCP resets, missed health checks) — previously the session sat hanging until the frontend tore it down
- fix for an `AttributeError` in `_reconnect_fast` that crashed the FAST reconnect path the first time it actually ran
- drop late SFU subscriber offers after the peer connection is closed

Vision-Agents sessions run long under concurrent load and were hitting the first issue in production.

## Changes

- Bump `getstream` minimum to `>=3.3.2,<4` in `agents-core/pyproject.toml` and `plugins/getstream/pyproject.toml`.
- Re-resolve `uv.lock`.