### PR TITLE
Add deprecation warning for heygen and link to liveavatar

### DIFF
--- a/plugins/heygen/README.md
+++ b/plugins/heygen/README.md
@@ -1,5 +1,10 @@
 # HeyGen Avatar Plugin for Vision Agents
 
+> [!WARNING]
+> **Deprecated.** This plugin is deprecated and will be removed in a future release.
+> Use the [`liveavatar`](../liveavatar/README.md) plugin instead — it targets LiveAvatar
+> (by HeyGen) via the supported LITE-mode integration path.
+
 Add realistic avatar video to your AI agents using HeyGen's streaming avatar API.
 
 ## Features

--- a/plugins/heygen/example/README.md
+++ b/plugins/heygen/example/README.md
@@ -1,5 +1,10 @@
 # HeyGen Avatar Examples
 
+> [!WARNING]
+> **Deprecated.** The HeyGen plugin is deprecated and will be removed in a future release.
+> Use the [`liveavatar`](../../liveavatar/README.md) plugin instead — it targets LiveAvatar
+> (by HeyGen) via the supported LITE-mode integration path.
+
 This directory contains examples of how to use the HeyGen plugin to add realistic avatar video to your AI agent.
 
 ## Examples


### PR DESCRIPTION
## Why
`heygen` plugin was not updated for a long time. 
In #534, we added the new `liveavatar` plugin to integrate with https://www.liveavatar.com/ by Heygen

## Changes
- Added deprecation notices to `heygen` readme.
