### PR TITLE
getstream.StreamEdge: use mono audio track by default

### DIFF
--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -393,7 +393,7 @@ class StreamEdge(EdgeTransport[StreamCall]):
         return standardize_connection
 
     def create_audio_track(
-        self, sample_rate: int = 48000, stereo: bool = True
+        self, sample_rate: int = 48000, stereo: bool = False
     ) -> AudioStreamTrack:
         return AudioStreamTrack(
             audio_buffer_size_ms=300_000,


### PR DESCRIPTION
Agent's audio output is a generated TTS speech.
It is mono 99% of the time, so using "stereo" layout only increases resampling costs
