### PR TITLE
Fixes for elevenlabs.STT

### DIFF
--- a/plugins/elevenlabs/tests/test_elevenlabs_stt.py
+++ b/plugins/elevenlabs/tests/test_elevenlabs_stt.py
@@ -28,6 +28,17 @@ class TestElevenLabsSTT:
         yield stt
         await stt.close()
 
+    @pytest.fixture
+    async def stt_short_keepalive(self):
+        stt = elevenlabs.STT(
+            language_code="en",
+            audio_chunk_duration_ms=100,
+            keepalive_interval_ms=500,
+        )
+        await stt.start()
+        yield stt
+        await stt.close()
+
     @pytest.mark.integration
     async def test_transcribe_mia_audio_16khz(self, stt, mia_audio_16khz, participant):
         """Test transcription with 16kHz audio (native sample rate)"""
@@ -76,12 +87,14 @@ class TestElevenLabsSTT:
 
     @pytest.mark.integration
     async def test_turn_events_emitted(self, stt, mia_audio_16khz, participant):
-        """Test that TurnStarted and TurnEnded are emitted"""
+        """One TurnStarted and exactly one TurnEnded per utterance."""
         await stt.process_audio(mia_audio_16khz, participant=participant)
 
         items = await stt.output.collect(timeout=10.0)
-        assert any(isinstance(i, TurnStarted) for i in items)
-        assert any(isinstance(i, TurnEnded) for i in items)
+        turn_started = [i for i in items if isinstance(i, TurnStarted)]
+        turn_ended = [i for i in items if isinstance(i, TurnEnded)]
+        assert len(turn_started) == 1
+        assert len(turn_ended) == 1
 
     @pytest.mark.integration
     async def test_multiple_audio_segments(
@@ -96,3 +109,23 @@ class TestElevenLabsSTT:
         finals = [i for i in items if isinstance(i, Transcript) and i.final]
         full_transcript = " ".join(t.text for t in finals)
         assert len(full_transcript) > 0
+
+    @pytest.mark.integration
+    async def test_connection_survives_idle_after_audio(
+        self, stt_short_keepalive, mia_audio_16khz, participant
+    ):
+        """WS must stay open across an idle window after real audio has been sent.
+
+        Exercises the keep-alive path: once a real chunk sets the queue's
+        sample_rate, ``get_samples`` raises ``QueueEmpty`` after 100 ms instead
+        of letting ``wait_for`` time out. Without the fix the silence frame
+        never fires and the server eventually closes the WS.
+        """
+        stt = stt_short_keepalive
+        await stt.process_audio(mia_audio_16khz, participant=participant)
+        await asyncio.sleep(stt.keepalive_interval_ms / 1000 * 3)
+        await stt.process_audio(mia_audio_16khz, participant=participant)
+
+        items = await stt.output.collect(timeout=15.0)
+        finals = [i for i in items if isinstance(i, Transcript) and i.final]
+        assert len(finals) >= 2

--- a/plugins/elevenlabs/vision_agents/plugins/elevenlabs/__init__.py
+++ b/plugins/elevenlabs/vision_agents/plugins/elevenlabs/__init__.py
@@ -1,7 +1,4 @@
+from .stt import ElevenlabsSTT as STT
 from .tts import TTS
-from .stt import STT
-
-# Re-export under the new namespace for convenience
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 __all__ = ["TTS", "STT"]

--- a/plugins/elevenlabs/vision_agents/plugins/elevenlabs/stt.py
+++ b/plugins/elevenlabs/vision_agents/plugins/elevenlabs/stt.py
@@ -226,9 +226,9 @@ class ElevenlabsSTT(stt.STT):
                     }
                 )
                 last_send_at = time.monotonic()
-            except Exception as e:
+            except Exception:
                 if not self.closed:
-                    logger.error(f"Error sending audio to ElevenLabs: {e}")
+                    logger.exception("Error sending audio to ElevenLabs")
                 break
 
     def _on_partial_transcript(self, transcription_data: dict[str, Any]):

--- a/plugins/elevenlabs/vision_agents/plugins/elevenlabs/stt.py
+++ b/plugins/elevenlabs/vision_agents/plugins/elevenlabs/stt.py
@@ -88,9 +88,9 @@ class ElevenlabsSTT(stt.STT):
         self.audio_chunk_duration_ms = audio_chunk_duration_ms
         self.keepalive_interval_ms = keepalive_interval_ms
 
-        # Pre-generated 2s of silence for keep-alive purposes.
-        silence_bytes = b"\x00" * (SAMPLE_RATE * audio_chunk_duration_ms // 1000 * 2)
-        self._silence_2s_b64 = base64.b64encode(silence_bytes).decode("utf-8")
+        # Pre-generated 1s of 16-bit PCM silence for keep-alive purposes.
+        silence_bytes = b"\x00" * (SAMPLE_RATE * 2)
+        self._silence_1s_b64 = base64.b64encode(silence_bytes).decode("utf-8")
 
         self._current_participant: Optional[Participant] = None
         self._connection_ready = asyncio.Event()
@@ -216,7 +216,7 @@ class ElevenlabsSTT(stt.STT):
                 # wall-clock time since the last actual send.
                 if time.monotonic() - last_send_at < keepalive_s:
                     continue
-                audio_base64 = self._silence_2s_b64
+                audio_base64 = self._silence_1s_b64
 
             try:
                 await self.connection.send(

--- a/plugins/elevenlabs/vision_agents/plugins/elevenlabs/stt.py
+++ b/plugins/elevenlabs/vision_agents/plugins/elevenlabs/stt.py
@@ -23,7 +23,10 @@ from vision_agents.core.utils.utils import cancel_and_wait
 logger = logging.getLogger(__name__)
 
 
-class STT(stt.STT):
+SAMPLE_RATE = 16000
+
+
+class ElevenlabsSTT(stt.STT):
     """
     ElevenLabs Scribe v2 Realtime Speech-to-Text implementation.
 
@@ -50,6 +53,7 @@ class STT(stt.STT):
         min_speech_duration_ms: int = 100,
         min_silence_duration_ms: int = 100,
         audio_chunk_duration_ms: int = 100,
+        keepalive_interval_ms: int = 5000,
         client: Optional[AsyncElevenLabs] = None,
     ):
         """
@@ -64,6 +68,8 @@ class STT(stt.STT):
             min_speech_duration_ms: Minimum speech duration in milliseconds.
             min_silence_duration_ms: Minimum silence duration in milliseconds.
             audio_chunk_duration_ms: Duration of audio chunks to send (100-1000ms recommended).
+            keepalive_interval_ms: Send a silence frame after this many ms of idle
+                so the server doesn't close the WS (e.g. while the user is muted).
             client: Optional pre-configured AsyncElevenLabs instance.
         """
         super().__init__(provider_name="elevenlabs")
@@ -80,6 +86,11 @@ class STT(stt.STT):
         self.min_speech_duration_ms = min_speech_duration_ms
         self.min_silence_duration_ms = min_silence_duration_ms
         self.audio_chunk_duration_ms = audio_chunk_duration_ms
+        self.keepalive_interval_ms = keepalive_interval_ms
+
+        # Pre-generated 2s of silence for keep-alive purposes.
+        silence_bytes = b"\x00" * (SAMPLE_RATE * audio_chunk_duration_ms // 1000 * 2)
+        self._silence_2s_b64 = base64.b64encode(silence_bytes).decode("utf-8")
 
         self._current_participant: Optional[Participant] = None
         self._connection_ready = asyncio.Event()
@@ -140,7 +151,7 @@ class STT(stt.STT):
             logger.warning("ElevenLabs connection already started")
             return
 
-        # Initialize audio queue with 5 second buffer limit
+        # Initialize audio queue with 10 second buffer limit
         self._audio_queue = AudioQueue(buffer_limit_ms=10000)
 
         # Configure realtime audio options (TypedDict)
@@ -148,7 +159,7 @@ class STT(stt.STT):
             "model_id": self.model_id,
             "language_code": self.language_code,
             "audio_format": AudioFormat.PCM_16000,
-            "sample_rate": 16000,
+            "sample_rate": SAMPLE_RATE,
             "commit_strategy": CommitStrategy.VAD,
             "vad_silence_threshold_secs": self.vad_silence_threshold_secs,
             "vad_threshold": self.vad_threshold,
@@ -183,44 +194,42 @@ class STT(stt.STT):
         self._connection_ready.set()
 
     async def _send_audio_loop(self):
-        """
-        Continuously send audio chunks from the queue to the WebSocket connection.
-        Batches audio into chunks of the configured duration.
-        """
-        try:
-            while not self.closed and self.connection is not None:
-                try:
-                    # Get audio chunk of configured duration from queue
-                    if self._audio_queue is not None:
-                        pcm_chunk = await self._audio_queue.get_duration(
-                            self.audio_chunk_duration_ms
-                        )
+        """Send audio chunks from the queue, falling back to silence on idle."""
+        keepalive_s = self.keepalive_interval_ms / 1000
+        last_send_at = time.monotonic()
 
-                        # Convert int16 samples to bytes
-                        audio_bytes = pcm_chunk.samples.tobytes()
+        while (
+            not self.closed
+            and self.connection is not None
+            and self._audio_queue is not None
+        ):
+            try:
+                pcm_chunk = await asyncio.wait_for(
+                    self._audio_queue.get_duration(self.audio_chunk_duration_ms),
+                    timeout=keepalive_s,
+                )
+                audio_bytes = pcm_chunk.samples.tobytes()
+                audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
+            except (asyncio.TimeoutError, asyncio.QueueEmpty):
+                # get_samples raises QueueEmpty after its own 100ms timeout,
+                # which bypasses wait_for — so gate the silence send on
+                # wall-clock time since the last actual send.
+                if time.monotonic() - last_send_at < keepalive_s:
+                    continue
+                audio_base64 = self._silence_2s_b64
 
-                        # Encode to base64
-                        audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
-
-                        # Send to ElevenLabs
-                        await self.connection.send(
-                            {
-                                "audio_base_64": audio_base64,
-                                "sample_rate": 16000,
-                            }
-                        )
-
-                except asyncio.QueueEmpty:
-                    # No audio available, wait a bit
-                    await asyncio.sleep(0.01)
-                except Exception as e:
-                    if not self.closed:
-                        logger.error(f"Error sending audio to ElevenLabs: {e}")
-                    break
-
-        except asyncio.CancelledError:
-            logger.debug("Audio send loop cancelled")
-            raise
+            try:
+                await self.connection.send(
+                    {
+                        "audio_base_64": audio_base64,
+                        "sample_rate": SAMPLE_RATE,
+                    }
+                )
+                last_send_at = time.monotonic()
+            except Exception as e:
+                if not self.closed:
+                    logger.error(f"Error sending audio to ElevenLabs: {e}")
+                break
 
     def _on_partial_transcript(self, transcription_data: dict[str, Any]):
         """
@@ -281,69 +290,55 @@ class STT(stt.STT):
         )
 
     def _on_committed_transcript(self, transcription_data: dict[str, Any]):
-        """
-        Event handler for final (committed) transcription results from ElevenLabs.
+        """Event handler for final (committed) transcription results from ElevenLabs."""
+        if not isinstance(transcription_data, dict):
+            raise TypeError(
+                f"Unexpected type for transcription data; "
+                f"expected dict, got {type(transcription_data)}"
+            )
 
-        Args:
-            transcription_data: The committed transcription result from ElevenLabs (dict)
-        """
+        # Empty text can come from the server committing our keep-alive silence
+        # (no turn in progress), or from a real end-of-segment where VAD closed
+        # the segment with no transcribable audio.
+        transcript_text = transcription_data.get("text", "").strip()
+        if not transcript_text and not self._turn_in_progress:
+            return
 
-        # Use the participant from the most recent process_audio call
         participant = self._current_participant
-
         if participant is None:
             raise ValueError(
                 "No participant set - audio must be processed with a participant"
             )
 
-        # Extract transcript text from dict
-        if isinstance(transcription_data, dict):
-            transcript_text = transcription_data.get("text", "").strip()
-            confidence = transcription_data.get("confidence", 0.0)
-            words = transcription_data.get("words")
-        else:
-            raise Exception(
-                "unexpected type for transcription data. expected dict got {}".format(
-                    type(transcription_data)
-                )
-            )
-
         if not transcript_text:
-            if self._turn_in_progress:
-                self._turn_in_progress = False
-                self._audio_start_time = None
-                self._emit_turn_ended_event(participant)
+            # _turn_in_progress is True (we returned earlier otherwise).
+            self._turn_in_progress = False
+            self._audio_start_time = None
+            self._emit_turn_ended_event(participant)
             return
 
-        # Build response metadata with word timestamps if available
-        other: Optional[dict[str, Any]] = None
-        if words:
-            other = {"words": words}
-
-        # Calculate processing time (time from first audio to transcript)
         processing_time_ms: Optional[float] = None
         if self._audio_start_time is not None:
             processing_time_ms = (time.perf_counter() - self._audio_start_time) * 1000
 
+        words = transcription_data.get("words")
         response_metadata = TranscriptResponse(
-            confidence=confidence,
+            confidence=transcription_data.get("confidence", 0.0),
             language=self.language_code,
             model_name=self.model_id,
-            other=other,
+            other={"words": words} if words else None,
             processing_time_ms=processing_time_ms,
         )
 
-        # Emit final transcript
         self._emit_transcript_event(
             transcript_text, participant, response_metadata, mode="final"
         )
-
-        # Reset audio start time for next utterance
         self._audio_start_time = None
 
-        # Signal turn ended (VAD committed the transcript)
-        self._turn_in_progress = False
-        self._emit_turn_ended_event(participant)
+        # Gated so a second commit for the same utterance does not double-fire.
+        if self._turn_in_progress:
+            self._turn_in_progress = False
+            self._emit_turn_ended_event(participant)
 
     def _on_error(self, error: Any):
         """


### PR DESCRIPTION
- Renamed "STT" -> "ElevenlabsSTT" to simplify code search
- Fixed duplicated TurnEnded event
- Fixed keep-alive mechanism. The websocket was getting closed after a few seconds without audio. Now, it sends 2s of silence every 5s to keep the connection open
