### PR TITLE
Backport changes from v0.5.9 to main

### DIFF
--- a/agents-core/pyproject.toml
+++ b/agents-core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "getstream[webrtc,telemetry]>=3.3.2,<4",
+    "getstream[webrtc,telemetry]>=3.3.4,<4",
     "aiortc>=1.14.0,<1.15.0",
     "av>=14.2.0, <17",
     "python-dotenv>=1.1.1",

--- a/agents-core/vision_agents/core/avatars/av_synchronizer.py
+++ b/agents-core/vision_agents/core/avatars/av_synchronizer.py
@@ -1,20 +1,28 @@
 import asyncio
 import collections
+import fractions
 import logging
+import time
 
 import av
 import av.frame
+from aiortc.mediastreams import MediaStreamError
 from getstream.video.rtc.track_util import PcmData
 from vision_agents.core.agents.inference import AudioOutputChunk, AudioOutputStream
 from vision_agents.core.utils.video_track import (
     QueuedVideoTrack,
     VideoTrackClosedError,
 )
-from vision_agents.core.utils.video_utils import ensure_even_dimensions
+from vision_agents.core.utils.video_utils import ensure_even_dimensions, resize_frame
 
 __all__ = ["AVSynchronizer"]
 
 logger = logging.getLogger(__name__)
+
+# aiortc hardcodes 30fps via its module-level VIDEO_PTIME; _SyncedVideoTrack
+# overrides next_timestamp() to honor its configured fps using these constants.
+_VIDEO_CLOCK_RATE = 90000
+_VIDEO_TIME_BASE = fractions.Fraction(1, _VIDEO_CLOCK_RATE)
 
 
 class AVSynchronizer:
@@ -87,7 +95,12 @@ class _SyncedVideoTrack(QueuedVideoTrack):
         """Queue a frame, delayed by the current audio buffer depth."""
         if self._stopped:
             return
-        frame = ensure_even_dimensions(frame)
+        if frame.width != self.width or frame.height != self.height:
+            frame = await asyncio.to_thread(
+                resize_frame, frame, self.width, self.height
+            )
+        else:
+            frame = ensure_even_dimensions(frame)
         release_at = (
             asyncio.get_running_loop().time() + self._audio_output_stream.buffered
         )
@@ -118,3 +131,17 @@ class _SyncedVideoTrack(QueuedVideoTrack):
         """Discard all pending frames and flush buffered audio."""
         self._pending.clear()
         await self._audio_output_stream.flush()
+
+    async def next_timestamp(self) -> tuple[int, fractions.Fraction]:
+        """Pace frames at ``self.fps`` instead of aiortc's hardcoded 30fps."""
+        if self.readyState != "live":
+            raise MediaStreamError
+        ptime = 1.0 / self.fps
+        if hasattr(self, "_timestamp"):
+            self._timestamp += int(ptime * _VIDEO_CLOCK_RATE)
+            wait = self._start + (self._timestamp / _VIDEO_CLOCK_RATE) - time.time()
+            await asyncio.sleep(wait)
+        else:
+            self._start = time.time()
+            self._timestamp = 0
+        return self._timestamp, _VIDEO_TIME_BASE

--- a/agents-core/vision_agents/core/avatars/av_synchronizer.py
+++ b/agents-core/vision_agents/core/avatars/av_synchronizer.py
@@ -45,7 +45,7 @@ class AVSynchronizer:
             width=width,
             height=height,
             fps=fps,
-            max_queue_size=max_queue_size,
+            max_queue_size=max(1, max_queue_size),
         )
 
     @property

--- a/agents-core/vision_agents/core/utils/video_utils.py
+++ b/agents-core/vision_agents/core/utils/video_utils.py
@@ -4,6 +4,7 @@ import io
 import logging
 
 import av
+import numpy as np
 from PIL import Image
 from PIL.Image import Resampling
 
@@ -91,40 +92,22 @@ def frame_to_png_bytes(frame: av.VideoFrame) -> bytes:
     return buf.getvalue()
 
 
-def resize_frame(self, frame: av.VideoFrame) -> av.VideoFrame:
+def resize_frame(frame: av.VideoFrame, width: int, height: int) -> av.VideoFrame:
+    """Resize to width x height preserving aspect ratio, padding remainder with black.
+
+    Matched-aspect fast path stays in the source pixel format (yuv420p from WebRTC),
+    skipping color conversion. Letterbox path converts to RGB for numpy padding.
     """
-    Resizes a video frame to target dimensions while maintaining the aspect ratio. The method centers the resized
-    image on a black background if the target dimensions do not match the original aspect ratio.
+    scale = min(width / frame.width, height / frame.height)
+    inner_w = max(2, int(frame.width * scale)) & ~1
+    inner_h = max(2, int(frame.height * scale)) & ~1
 
-    Parameters:
-        frame (av.VideoFrame): The input video frame to be resized.
+    if inner_w == width and inner_h == height:
+        return frame.reformat(width=width, height=height)
 
-    Returns:
-        av.VideoFrame: The output video frame after resizing, maintaining the original aspect ratio.
-
-    Raises:
-        None
-    """
-    img = frame.to_image()
-
-    # Calculate scaling to maintain aspect ratio
-    src_width, src_height = img.size
-    target_width, target_height = self.width, self.height
-
-    # Calculate scale factor (fit within target dimensions)
-    scale = min(target_width / src_width, target_height / src_height)
-    new_width = int(src_width * scale)
-    new_height = int(src_height * scale)
-
-    # Resize with aspect ratio maintained
-    resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-
-    # Create black background at target resolution
-    result = Image.new("RGB", (target_width, target_height), (0, 0, 0))
-
-    # Paste resized image centered
-    x_offset = (target_width - new_width) // 2
-    y_offset = (target_height - new_height) // 2
-    result.paste(resized, (x_offset, y_offset))
-
-    return av.VideoFrame.from_image(result)
+    rgb = frame.reformat(width=inner_w, height=inner_h, format="rgb24")
+    out = np.zeros((height, width, 3), dtype=np.uint8)
+    y0 = (height - inner_h) // 2
+    x0 = (width - inner_w) // 2
+    out[y0 : y0 + inner_h, x0 : x0 + inner_w] = rgb.to_ndarray()
+    return av.VideoFrame.from_ndarray(out, format="rgb24")

--- a/plugins/anam/tests/test_anam_avatar.py
+++ b/plugins/anam/tests/test_anam_avatar.py
@@ -41,3 +41,20 @@ class TestAnamAvatar:
     async def test_audio_output(self):
         avatar = _make_avatar()
         assert isinstance(avatar.audio_output(), AudioOutputStream)
+
+    async def test_init_buffer_seconds_sets_queue_size(self):
+        avatar = _make_avatar(buffer_seconds=2.5)
+        assert avatar._sync._video_output._pending.maxlen == 75
+
+    async def test_init_zero_buffer_seconds_raises(self):
+        with pytest.raises(ValueError, match="buffer_seconds must be > 0"):
+            _make_avatar(buffer_seconds=0)
+
+    async def test_init_custom_fps(self):
+        avatar = _make_avatar(fps=60, buffer_seconds=2.0)
+        assert avatar._sync._video_output.fps == 60
+        assert avatar._sync._video_output._pending.maxlen == 120
+
+    async def test_init_zero_fps_raises(self):
+        with pytest.raises(ValueError, match="fps must be > 0"):
+            _make_avatar(fps=0)

--- a/plugins/anam/vision_agents/plugins/anam/anam_avatar.py
+++ b/plugins/anam/vision_agents/plugins/anam/anam_avatar.py
@@ -53,8 +53,10 @@ class AnamAvatar(Avatar):
         client_options: ClientOptions | None = None,
         connect_timeout: float | None = None,
         session_ready_timeout: float | None = None,
-        width: int = 1920,
-        height: int = 1080,
+        width: int = 720,
+        height: int = 480,
+        fps: int = 30,
+        buffer_seconds: float = 1.0,
     ):
         """Initialize the Anam avatar publisher.
 
@@ -68,6 +70,9 @@ class AnamAvatar(Avatar):
                 None means wait indefinitely.
             width: Output video width in pixels.
             height: Output video height in pixels.
+            fps: Output video frame rate. Must be > 0.
+            buffer_seconds: Max video buffer depth in seconds. Caps how many frames
+                can be queued ahead of audio playback. Must be > 0.
         """
         super().__init__()
         api_key = api_key or os.getenv("ANAM_API_KEY")
@@ -76,6 +81,10 @@ class AnamAvatar(Avatar):
         avatar_id = avatar_id or os.getenv("ANAM_AVATAR_ID")
         if not avatar_id:
             raise ValueError("Anam avatar ID not provided")
+        if buffer_seconds <= 0:
+            raise ValueError("buffer_seconds must be > 0")
+        if fps <= 0:
+            raise ValueError("fps must be > 0")
 
         self._client = AnamClient(
             api_key=api_key,
@@ -93,7 +102,10 @@ class AnamAvatar(Avatar):
         self._client.on(AnamEvent.SESSION_READY)(self._on_session_ready)
 
         self._sync = AVSynchronizer(
-            width=width, height=height, fps=30, max_queue_size=30 * 20
+            width=width,
+            height=height,
+            fps=fps,
+            max_queue_size=int(fps * buffer_seconds),
         )
 
         self._connect_timeout = connect_timeout

--- a/plugins/decart/vision_agents/plugins/decart/decart_video_track.py
+++ b/plugins/decart/vision_agents/plugins/decart/decart_video_track.py
@@ -48,7 +48,9 @@ class DecartVideoTrack(VideoStreamTrack):
         if not isinstance(frame, av.VideoFrame):
             return
         if frame.width != self.width or frame.height != self.height:
-            frame = await asyncio.to_thread(resize_frame, frame, self.width, self.height)
+            frame = await asyncio.to_thread(
+                resize_frame, frame, self.width, self.height
+            )
         self.frame_queue.put_latest_nowait(frame)
 
     async def recv(self) -> av.VideoFrame:

--- a/plugins/decart/vision_agents/plugins/decart/decart_video_track.py
+++ b/plugins/decart/vision_agents/plugins/decart/decart_video_track.py
@@ -48,7 +48,7 @@ class DecartVideoTrack(VideoStreamTrack):
         if not isinstance(frame, av.VideoFrame):
             return
         if frame.width != self.width or frame.height != self.height:
-            frame = await asyncio.to_thread(resize_frame, self, frame)
+            frame = await asyncio.to_thread(resize_frame, frame, self.width, self.height)
         self.frame_queue.put_latest_nowait(frame)
 
     async def recv(self) -> av.VideoFrame:

--- a/plugins/getstream/pyproject.toml
+++ b/plugins/getstream/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",
-    "getstream[webrtc,telemetry]>=3.3.2,<4",
+    "getstream[webrtc,telemetry]>=3.3.4,<4",
 ]
 
 [project.urls]

--- a/plugins/lemonslice/vision_agents/plugins/lemonslice/lemonslice_avatar.py
+++ b/plugins/lemonslice/vision_agents/plugins/lemonslice/lemonslice_avatar.py
@@ -52,8 +52,10 @@ class LemonSliceAvatar(Avatar):
         livekit_url: str | None = None,
         livekit_api_key: str | None = None,
         livekit_api_secret: str | None = None,
-        width: int = 1920,
-        height: int = 1080,
+        width: int = 1280,
+        height: int = 720,
+        fps: int = 30,
+        buffer_seconds: float = 1.0,
     ):
         """Initialize the LemonSlice avatar publisher.
 
@@ -69,8 +71,15 @@ class LemonSliceAvatar(Avatar):
             livekit_api_secret: LiveKit API secret. Uses LIVEKIT_API_SECRET env var if not provided.
             width: Output video width in pixels.
             height: Output video height in pixels.
+            fps: Output video frame rate. Must be > 0.
+            buffer_seconds: Max video buffer depth in seconds. Caps how many frames
+                can be queued ahead of audio playback. Must be > 0.
         """
         super().__init__()
+        if buffer_seconds <= 0:
+            raise ValueError("buffer_seconds must be > 0")
+        if fps <= 0:
+            raise ValueError("fps must be > 0")
         agent_id = agent_id or os.getenv("LEMONSLICE_AGENT_ID")
         agent_image_url = agent_image_url or os.getenv("LEMONSLICE_AGENT_IMAGE_URL")
 
@@ -93,7 +102,12 @@ class LemonSliceAvatar(Avatar):
             livekit_api_key=livekit_api_key,
             livekit_api_secret=livekit_api_secret,
         )
-        self._sync = AVSynchronizer(width=width, height=height)
+        self._sync = AVSynchronizer(
+            width=width,
+            height=height,
+            fps=fps,
+            max_queue_size=int(fps * buffer_seconds),
+        )
 
         self._connected = False
         self._audio_input_task: asyncio.Task[None] | None = None

--- a/plugins/liveavatar/vision_agents/plugins/liveavatar/liveavatar_avatar.py
+++ b/plugins/liveavatar/vision_agents/plugins/liveavatar/liveavatar_avatar.py
@@ -52,8 +52,10 @@ class LiveAvatar(Avatar):
         max_session_duration: int | None = None,
         video_quality: str = "high",
         video_encoding: str = "H264",
-        width: int = 1920,
-        height: int = 1080,
+        width: int = 1280,
+        height: int = 720,
+        fps: int = 30,
+        buffer_seconds: float = 1.0,
     ) -> None:
         """Initialize the LiveAvatar plugin.
 
@@ -68,8 +70,15 @@ class LiveAvatar(Avatar):
             video_encoding: One of "H264", "VP8".
             width: Output video width in pixels.
             height: Output video height in pixels.
+            fps: Output video frame rate. Must be > 0.
+            buffer_seconds: Max video buffer depth in seconds. Caps how many frames
+                can be queued ahead of audio playback. Must be > 0.
         """
         super().__init__()
+        if buffer_seconds <= 0:
+            raise ValueError("buffer_seconds must be > 0")
+        if fps <= 0:
+            raise ValueError("fps must be > 0")
 
         api_key = api_key or os.getenv("LIVEAVATAR_API_KEY")
         if not api_key:
@@ -88,7 +97,12 @@ class LiveAvatar(Avatar):
             on_audio=self._on_audio_frame,
             on_disconnect=self._on_disconnect,
         )
-        self._sync = AVSynchronizer(width=width, height=height)
+        self._sync = AVSynchronizer(
+            width=width,
+            height=height,
+            fps=fps,
+            max_queue_size=int(fps * buffer_seconds),
+        )
 
         self._avatar_id = avatar_id
         self._is_sandbox = is_sandbox

--- a/tests/test_avatars/test_av_synchronizer.py
+++ b/tests/test_avatars/test_av_synchronizer.py
@@ -152,3 +152,22 @@ class TestAVSynchronizer:
         sync.video_output.stop()
         with pytest.raises(VideoTrackClosedError):
             await sync.video_output.recv()
+
+    async def test_mismatched_frame_is_resized_to_track_dims(
+        self, sync: AVSynchronizer
+    ):
+        """Frames not matching the track's dims should be resized on the way in."""
+        await sync.write_video(_make_frame(1280, 720, "red"))
+
+        received = await sync.video_output.recv()
+        assert received.width == 640
+        assert received.height == 480
+
+    @pytest.mark.parametrize("fps,expected_delta", [(60, 1500), (30, 3000), (15, 6000)])
+    async def test_next_timestamp_paces_at_configured_fps(
+        self, fps: int, expected_delta: int
+    ):
+        sync = AVSynchronizer(width=640, height=480, fps=fps, max_queue_size=10)
+        pts1, _ = await sync.video_output.next_timestamp()
+        pts2, _ = await sync.video_output.next_timestamp()
+        assert pts2 - pts1 == expected_delta

--- a/tests/test_video_utils.py
+++ b/tests/test_video_utils.py
@@ -4,7 +4,7 @@ import av
 import numpy as np
 from fractions import Fraction
 
-from vision_agents.core.utils.video_utils import ensure_even_dimensions
+from vision_agents.core.utils.video_utils import ensure_even_dimensions, resize_frame
 
 
 class TestEnsureEvenDimensions:
@@ -57,3 +57,57 @@ class TestEnsureEvenDimensions:
 
         assert result.width == 1728  # Already even
         assert result.height == 1082  # Cropped by 1
+
+
+def _solid_rgb_frame(
+    width: int, height: int, color: tuple[int, int, int]
+) -> av.VideoFrame:
+    arr = np.full((height, width, 3), color, dtype=np.uint8)
+    return av.VideoFrame.from_ndarray(arr, format="rgb24")
+
+
+class TestResizeFrame:
+    def test_resizes_down_to_target_size(self):
+        src = _solid_rgb_frame(1280, 720, (200, 50, 50))
+
+        out = resize_frame(src, 640, 480)
+
+        assert out.width == 640
+        assert out.height == 480
+
+    def test_aspect_preserved_letterboxes_top_and_bottom(self):
+        # 2:1 source into 4:3 target: inner box 640x320, vertical bars at top/bottom.
+        src = _solid_rgb_frame(200, 100, (50, 200, 50))
+
+        out = resize_frame(src, 640, 480)
+        arr = out.to_ndarray(format="rgb24")
+
+        assert out.width == 640
+        assert out.height == 480
+        assert np.array_equal(arr[0, 320, :], np.array([0, 0, 0], dtype=np.uint8))
+        assert np.array_equal(arr[479, 320, :], np.array([0, 0, 0], dtype=np.uint8))
+        # Center of frame is inside the inner box; reformat dithers, so allow tolerance.
+        center = arr[240, 320, :].astype(int)
+        assert center[1] > center[0] and center[1] > center[2]
+
+    def test_aspect_preserved_letterboxes_left_and_right(self):
+        # 1:2 source into 4:3 target: inner box 240x480, bars on left/right.
+        src = _solid_rgb_frame(100, 200, (50, 50, 200))
+
+        out = resize_frame(src, 640, 480)
+        arr = out.to_ndarray(format="rgb24")
+
+        assert out.width == 640
+        assert out.height == 480
+        assert np.array_equal(arr[240, 0, :], np.array([0, 0, 0], dtype=np.uint8))
+        assert np.array_equal(arr[240, 639, :], np.array([0, 0, 0], dtype=np.uint8))
+        center = arr[240, 320, :].astype(int)
+        assert center[2] > center[0] and center[2] > center[1]
+
+    def test_exact_size_returns_same_dimensions(self):
+        src = _solid_rgb_frame(640, 480, (100, 100, 100))
+
+        out = resize_frame(src, 640, 480)
+
+        assert out.width == 640
+        assert out.height == 480

--- a/uv.lock
+++ b/uv.lock
@@ -7369,7 +7369,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'dev'" },
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "fastapi", specifier = ">=0.135.1" },
-    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.2,<4" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.4,<4" },
     { name = "mcp", specifier = ">=1.23.3,<2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -7781,7 +7781,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.2,<4" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.4,<4" },
     { name = "vision-agents", editable = "agents-core" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1983,7 +1983,7 @@ wheels = [
 
 [[package]]
 name = "getstream"
-version = "3.3.2"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dataclasses-json" },
@@ -1998,9 +1998,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "twirp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/8b/ac4dfb7840b0821baf0509e2ddfcfc32b64ae7967def05df05271ef04788/getstream-3.3.2.tar.gz", hash = "sha256:b8df0ddf976452caa063a8ed4d617220bdb39483e0ea3b0a6eb6faaeff609db7", size = 527378, upload-time = "2026-05-12T15:45:01.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/d0/5398f3e712004aba1d629ef7362a6c941967ef052e066fe5f0354014bd12/getstream-3.3.4.tar.gz", hash = "sha256:091226d96e8e7f51b8feaaaa09d33eae37df8e799039a3c96032e54594501e98", size = 528252, upload-time = "2026-05-15T12:03:03.61Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/49/e90aa9e4880308c842a3d4f463f3f150ab48abe056b857ebce055e540f32/getstream-3.3.2-py3-none-any.whl", hash = "sha256:2d312f601254ee07b5e82e40bef8c25e81c4d3db744a8faed1e49e97b4df739a", size = 335271, upload-time = "2026-05-12T15:45:02.823Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/4c5452cee3aa9af1fa873b93bdc944611af27abbfa4b92cab0e31e680e94/getstream-3.3.4-py3-none-any.whl", hash = "sha256:9ba009256fb1a99015acb5cf681ca7df52604f3a0214bea4c1831155156e45d1", size = 336140, upload-time = "2026-05-15T12:03:01.961Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Backport changes from v0.5.9 to main:

- allow resizing the avatars output
- reduce default video buffer 10s -> 1s
- update decart to use the common resize_frame func
- bump min getstream version to 3.3.4