### PR TITLE
fix(core): drop noisy redis warning, surface actionable hint on use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-- **Optional `redis` extra**: importing `vision_agents.core` no longer emits a `UserWarning` when the `redis` package is absent. The warning was noise for the majority of users who don't use `RedisSessionKVStore`; instead, attempting to import `vision_agents.core.agents.session_registry.redis_store` directly raises a `ModuleNotFoundError` with an actionable install hint ("`pip install 'vision-agents[redis]'`"), matching the FastAPI optional-extra pattern.
+- **Optional `redis` extra**: importing `vision_agents.core` no longer emits a `UserWarning` when the `redis` package is absent. The warning was noise for the majority of users who don't use `RedisSessionKVStore`; instead, attempting to import `vision_agents.core.agents.session_registry.redis_store` directly raises a `ModuleNotFoundError` with an actionable install hint ("`pip install 'vision-agents[redis]'`"), matching the FastAPI optional-extra pattern. (#562)
 
 # v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+
+- **Optional `redis` extra**: importing `vision_agents.core` no longer emits a `UserWarning` when the `redis` package is absent. The warning was noise for the majority of users who don't use `RedisSessionKVStore`; instead, attempting to import `vision_agents.core.agents.session_registry.redis_store` directly raises a `ModuleNotFoundError` with an actionable install hint ("`pip install 'vision-agents[redis]'`"), matching the FastAPI optional-extra pattern.
+
 # v0.6.0
 
 ## Breaking Changes

--- a/agents-core/vision_agents/core/__init__.py
+++ b/agents-core/vision_agents/core/__init__.py
@@ -26,14 +26,9 @@ try:
     from vision_agents.core.agents.session_registry import RedisSessionKVStore
 
     __all__ += ["RedisSessionKVStore"]
-except ImportError as e:
-    import warnings
-
-    if e.name and e.name.startswith("redis") or "RedisSessionKVStore" in str(e):
-        warnings.warn(
-            "Optional dependency 'redis' is not installed. "
-            "Install the [redis] extra to enable RedisSessionKVStore.",
-            stacklevel=2,
-        )
-    else:
+except ImportError as exc:
+    redis_missing = (
+        exc.name and exc.name.startswith("redis")
+    ) or "RedisSessionKVStore" in str(exc)
+    if not redis_missing:
         raise

--- a/agents-core/vision_agents/core/agents/session_registry/redis_store.py
+++ b/agents-core/vision_agents/core/agents/session_registry/redis_store.py
@@ -1,7 +1,14 @@
 import inspect
 import logging
 
-import redis.asyncio as redis
+try:
+    import redis.asyncio as redis
+except ImportError as err:
+    raise ModuleNotFoundError(
+        "Redis support requires the `redis` extra. "
+        "Install it with: pip install 'vision-agents[redis]'",
+        name="redis",
+    ) from err
 
 from .store import SessionKVStore
 

--- a/agents-core/vision_agents/core/agents/session_registry/redis_store.py
+++ b/agents-core/vision_agents/core/agents/session_registry/redis_store.py
@@ -4,11 +4,13 @@ import logging
 try:
     import redis.asyncio as redis
 except ImportError as err:
-    raise ModuleNotFoundError(
-        "Redis support requires the `redis` extra. "
-        "Install it with: pip install 'vision-agents[redis]'",
-        name="redis",
-    ) from err
+    if err.name and err.name.startswith("redis"):
+        raise ModuleNotFoundError(
+            "Redis support requires the `redis` extra. "
+            "Install it with: pip install 'vision-agents[redis]'",
+            name="redis",
+        ) from err
+    raise
 
 from .store import SessionKVStore
 

--- a/tests/test_agents/test_session_registry/test_redis_optional.py
+++ b/tests/test_agents/test_session_registry/test_redis_optional.py
@@ -1,0 +1,52 @@
+"""Behavior of the Redis optional extra when the `redis` package is absent.
+
+Both tests run in a subprocess that blocks ``import redis`` so they don't
+depend on whether the dev venv has the redis package installed.
+"""
+
+import subprocess
+import sys
+
+
+def _run_with_redis_blocked(snippet: str) -> subprocess.CompletedProcess[str]:
+    code = "import sys\nsys.modules['redis'] = None\n" + snippet
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_importing_vision_agents_core_is_silent_when_redis_missing() -> None:
+    result = _run_with_redis_blocked(
+        "import warnings\n"
+        "with warnings.catch_warnings(record=True) as w:\n"
+        "    warnings.simplefilter('always')\n"
+        "    import vision_agents.core  # noqa: F401\n"
+        "print(len(w))\n"
+        "for entry in w:\n"
+        "    print(repr(entry.message))\n"
+    )
+    assert result.returncode == 0, result.stderr
+    first_line = result.stdout.splitlines()[0]
+    assert first_line == "0", (
+        f"expected zero warnings from `import vision_agents.core`, got:\n{result.stdout}"
+    )
+
+
+def test_direct_redis_store_import_raises_actionable_error() -> None:
+    result = _run_with_redis_blocked(
+        "try:\n"
+        "    import vision_agents.core.agents.session_registry.redis_store  # noqa: F401\n"
+        "except ModuleNotFoundError as exc:\n"
+        "    print(exc.name)\n"
+        "    print(exc)\n"
+        "else:\n"
+        "    raise SystemExit('expected ModuleNotFoundError')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == "redis"
+    message = "\n".join(lines[1:])
+    assert "vision-agents[redis]" in message


### PR DESCRIPTION
## Why

Importing anything from `vision_agents.core` currently emits a `UserWarning` saying "Optional dependency 'redis' is not installed" whenever the `[redis]` extra isn't installed. The vast majority of users never touch `RedisSessionKVStore` — for them this is pure noise on every script start, on every notebook reload, and (now) on every `vision-agents` CLI invocation.

This switches to the **FastAPI optional-extra pattern**: the import is silent for non-users, and the actionable install hint fires only when a user actually reaches for the Redis store.

Before:

```python
>>> from vision_agents.core import Agent
UserWarning: Optional dependency 'redis' is not installed. Install the [redis] extra to enable RedisSessionKVStore.
```

After:

```python
>>> from vision_agents.core import Agent           # silent

>>> from vision_agents.core.agents.session_registry.redis_store import RedisSessionKVStore
ModuleNotFoundError: Redis support requires the `redis` extra. Install it with: pip install 'vision-agents[redis]'
```

`redis_store.py` is now the source of truth — it guards `import redis.asyncio` and raises `ModuleNotFoundError(name="redis")` with the install hint. The two re-exports (`vision_agents.core.__init__` and `session_registry/__init__`) keep their existing try/except silent-skip, just without the `warnings.warn(...)` call. Users who hit the wrapped `ModuleNotFoundError` get a precise, copy-pasteable fix; users who do `from vision_agents.core import RedisSessionKVStore` without the extra see Python's standard "cannot import name" message, same as any other missing symbol.

Two subprocess-based tests in `tests/test_agents/test_session_registry/test_redis_optional.py` lock the contract — one asserts `import vision_agents.core` emits zero warnings when `redis` is blocked, the other asserts the direct `redis_store` import raises a `ModuleNotFoundError` whose message contains `vision-agents[redis]`. Subprocess isolation avoids polluting the dev venv's `sys.modules`.