### PR TITLE
fix(cli): use agent.simple_response in scaffold template

### DIFF
--- a/agents-core/vision_agents/cli/init/templates/agent.py.j2
+++ b/agents-core/vision_agents/cli/init/templates/agent.py.j2
@@ -21,7 +21,7 @@ async def create_agent(**kwargs) -> Agent:
 async def join_call(agent: Agent, call_type: str, call_id: str, **kwargs) -> None:
     call = await agent.create_call(call_type, call_id)
     async with agent.join(call):
-        await agent.llm.simple_response(text="Say hi and introduce yourself.")
+        await agent.simple_response(text="Say hi and introduce yourself.")
         await agent.finish()
 
 


### PR DESCRIPTION
## Why

The CLI scaffold template called `agent.llm.simple_response(...)` and awaited it. `LLM.simple_response` returns an `AsyncIterator`, not a coroutine, so the generated project crashed on first run. `Agent.simple_response` is the async wrapper meant for this use case.