### PR TITLE
Fix integration suite

### DIFF
--- a/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
+++ b/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
@@ -878,6 +878,9 @@ class Realtime(realtime.Realtime, Warmable[SileroVADSessionPool]):
             try:
                 output = await connection.await_output()
                 result = await output[1].receive()
+                if result is None:
+                    logger.debug("Stream ended (receive returned None)")
+                    break
                 if result.value and result.value.bytes_:
                     try:
                         response_data = result.value.bytes_.decode("utf-8")

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -69,9 +69,10 @@ class TestGeminiRealtimeProcessEvents:
         await rt._process_events()
 
         items = rt.output.peek()
-        assert len(items) == 1
-        assert isinstance(items[0], RealtimeUserTranscript)
-        assert items[0].text == "hello"
+        assert any(isinstance(i, RealtimeUserSpeechStarted) for i in items)
+        transcripts = [i for i in items if isinstance(i, RealtimeUserTranscript)]
+        assert len(transcripts) == 1
+        assert transcripts[0].text == "hello"
 
     async def test_output_transcription(self):
         rt = _make_realtime()
@@ -591,8 +592,7 @@ class TestGeminiRealtimeIntegration:
         async for _ in realtime.simple_response("Hello, can you hear me?"):
             pass
 
-        await asyncio.sleep(3.0)
-        items = realtime.output.peek()
+        items = await realtime.output.collect(timeout=10.0)
         audio = [i for i in items if isinstance(i, RealtimeAudioOutput)]
         agent_started = [i for i in items if isinstance(i, RealtimeAgentSpeechStarted)]
         agent_ended = [i for i in items if isinstance(i, RealtimeAgentSpeechEnded)]
@@ -601,16 +601,22 @@ class TestGeminiRealtimeIntegration:
         assert len(agent_ended) >= 1
         assert any(not e.interrupted for e in agent_ended)
 
-    async def test_audio_sending_flow(self, realtime, mia_audio_16khz):
+    async def test_audio_sending_flow(self, realtime, mia_audio_16khz, silence_1s_16khz):
         async for _ in realtime.simple_response(
             "Listen to the following story, what is Mia looking for?"
         ):
             pass
         await asyncio.sleep(10.0)
-        await realtime.simple_audio_response(mia_audio_16khz)
+        participant = Participant(original=None, user_id="u", id="u")
+        await realtime.simple_audio_response(mia_audio_16khz, participant)
 
-        await asyncio.sleep(10.0)
-        items = realtime.output.peek()
+        # Emulate a real pause in utterance so Gemini commits the turn and the
+        # model starts responding (which is what triggers user_speech_ended).
+        for _ in range(3):
+            await realtime.simple_audio_response(silence_1s_16khz, participant)
+            await asyncio.sleep(1.0)
+
+        items = await realtime.output.collect(15.0)
         audio = [i for i in items if isinstance(i, RealtimeAudioOutput)]
         user_started = [i for i in items if isinstance(i, RealtimeUserSpeechStarted)]
         user_ended = [i for i in items if isinstance(i, RealtimeUserSpeechEnded)]

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -604,11 +604,6 @@ class TestGeminiRealtimeIntegration:
     async def test_audio_sending_flow(
         self, realtime, mia_audio_16khz, silence_1s_16khz
     ):
-        async for _ in realtime.simple_response(
-            "Listen to the following story, what is Mia looking for?"
-        ):
-            pass
-        await asyncio.sleep(10.0)
         participant = Participant(original=None, user_id="u", id="u")
         await realtime.simple_audio_response(mia_audio_16khz, participant)
 
@@ -618,7 +613,7 @@ class TestGeminiRealtimeIntegration:
             await realtime.simple_audio_response(silence_1s_16khz, participant)
             await asyncio.sleep(1.0)
 
-        items = await realtime.output.collect(15.0)
+        items = await realtime.output.collect(timeout=15.0)
         audio = [i for i in items if isinstance(i, RealtimeAudioOutput)]
         user_started = [i for i in items if isinstance(i, RealtimeUserSpeechStarted)]
         user_ended = [i for i in items if isinstance(i, RealtimeUserSpeechEnded)]

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -601,7 +601,9 @@ class TestGeminiRealtimeIntegration:
         assert len(agent_ended) >= 1
         assert any(not e.interrupted for e in agent_ended)
 
-    async def test_audio_sending_flow(self, realtime, mia_audio_16khz, silence_1s_16khz):
+    async def test_audio_sending_flow(
+        self, realtime, mia_audio_16khz, silence_1s_16khz
+    ):
         async for _ in realtime.simple_response(
             "Listen to the following story, what is Mia looking for?"
         ):

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -336,6 +336,9 @@ class GeminiRealtime(realtime.Realtime):
 
     async def _establish_session(self):
         """Create a new Gemini WebSocket session without managing the processing task."""
+        # Reset per-turn flags so a reconnect mid-utterance doesn't inherit stale state.
+        self._agent_audio_started = False
+        self._user_audio_started = False
         logger.debug("Connecting to Gemini live, config set to %s", self._base_config)
         self._real_session = await self._exit_stack.enter_async_context(
             self._client.aio.live.connect(  # type: ignore[arg-type]
@@ -420,6 +423,12 @@ class GeminiRealtime(realtime.Realtime):
             self._processing_task.cancel()
             await self._processing_task
 
+    def _end_user_speech_if_started(self) -> None:
+        """Emit user_speech_ended once per user turn and clear the flag."""
+        if self._user_audio_started:
+            self._user_audio_started = False
+            self._emit_user_speech_ended()
+
     async def _process_events(self) -> bool:
         """
         Process events from Gemini Live API.
@@ -448,9 +457,7 @@ class GeminiRealtime(realtime.Realtime):
             if server_content and server_content.model_turn:
                 handled = True
                 # Model is responding → user has finished speaking.
-                if self._user_audio_started:
-                    self._user_audio_started = False
-                    self._emit_user_speech_ended()
+                self._end_user_speech_if_started()
                 # Store the resumption id so we can resume a broken connection
                 if server_message.session_resumption_update:
                     update = server_message.session_resumption_update
@@ -485,6 +492,10 @@ class GeminiRealtime(realtime.Realtime):
                 handled = True
 
             if server_message.tool_call:
+                # tool_call is an independent turn terminator per the Live API
+                # handleTurn example (https://ai.google.dev/gemini-api/docs/live-tools),
+                # so it can arrive without a preceding model_turn.
+                self._end_user_speech_if_started()
                 self._run_tool_in_background(
                     self._handle_tool_calls(server_message.tool_call)
                 )

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -33,8 +33,6 @@ from google.genai.types import (
     SpeechConfigDict,
     StartSensitivity,
     TurnCoverage,
-    VadSignalType,
-    VoiceActivityType,
     VoiceConfigDict,
 )
 from vision_agents.core.edge.types import Participant
@@ -199,6 +197,9 @@ class GeminiRealtime(realtime.Realtime):
         self._executor = ThreadPoolExecutor(max_workers=1)
         # Gemini Live has no agent-speech-started wire event; fire once per turn.
         self._agent_audio_started: bool = False
+        # Gemini Live's user VAD signals are allowlisted-only; derive user-speech
+        # boundaries from input_transcription + model_turn instead.
+        self._user_audio_started: bool = False
 
     @property
     def _session(self):
@@ -429,30 +430,12 @@ class GeminiRealtime(realtime.Realtime):
 
             handled = False
 
-            # VAD signals at the message level: explicit user speech start/end.
-            vad_signal = server_message.voice_activity_detection_signal
-            voice_activity = server_message.voice_activity
-            if vad_signal and vad_signal.vad_signal_type:
-                if vad_signal.vad_signal_type == VadSignalType.VAD_SIGNAL_TYPE_SOS:
-                    self._emit_user_speech_started()
-                elif vad_signal.vad_signal_type == VadSignalType.VAD_SIGNAL_TYPE_EOS:
-                    self._emit_user_speech_ended()
-                handled = True
-            elif voice_activity and voice_activity.voice_activity_type:
-                if (
-                    voice_activity.voice_activity_type
-                    == VoiceActivityType.ACTIVITY_START
-                ):
-                    self._emit_user_speech_started()
-                elif (
-                    voice_activity.voice_activity_type == VoiceActivityType.ACTIVITY_END
-                ):
-                    self._emit_user_speech_ended()
-                handled = True
-
             if server_content and server_content.input_transcription:
                 text = server_content.input_transcription.text
                 if text:
+                    if not self._user_audio_started:
+                        self._user_audio_started = True
+                        self._emit_user_speech_started()
                     self._emit_user_speech_transcription(text=text, mode="delta")
                     handled = True
 
@@ -464,6 +447,10 @@ class GeminiRealtime(realtime.Realtime):
 
             if server_content and server_content.model_turn:
                 handled = True
+                # Model is responding → user has finished speaking.
+                if self._user_audio_started:
+                    self._user_audio_started = False
+                    self._emit_user_speech_ended()
                 # Store the resumption id so we can resume a broken connection
                 if server_message.session_resumption_update:
                     update = server_message.session_resumption_update

--- a/plugins/openai/tests/test_openai_realtime.py
+++ b/plugins/openai/tests/test_openai_realtime.py
@@ -131,8 +131,7 @@ class TestOpenAIRealtimeIntegration:
         async for _ in realtime.simple_response("Hello, can you hear me?"):
             pass
 
-        await asyncio.sleep(3.0)
-        items = realtime.output.peek()
+        items = await realtime.output.collect(10.0)
         audio = [i for i in items if isinstance(i, RealtimeAudioOutput)]
         done = [i for i in items if isinstance(i, RealtimeAudioOutputDone)]
         agent_started = [i for i in items if isinstance(i, RealtimeAgentSpeechStarted)]
@@ -163,12 +162,21 @@ class TestOpenAIRealtimeIntegration:
             pass
         await asyncio.sleep(5.0)
 
-        await realtime.simple_audio_response(
-            audio_48khz, Participant(original=None, user_id="u", id="u")
-        )
+        participant = Participant(original=None, user_id="u", id="u")
+        await realtime.simple_audio_response(audio_48khz, participant)
 
-        await asyncio.sleep(10.0)
-        items = realtime.output.peek()
+        # Emulate a real pause in utterance so semantic_vad commits the turn:
+        # 1s silence × 3 with 1s sleeps between.
+        silence_1s_48khz = PcmData(
+            samples=np.zeros(48000, dtype=np.int16),
+            sample_rate=48000,
+            format=AudioFormat.S16,
+        )
+        for _ in range(3):
+            await realtime.simple_audio_response(silence_1s_48khz, participant)
+            await asyncio.sleep(1.0)
+
+        items = await realtime.output.collect(10.0)
         audio = [i for i in items if isinstance(i, RealtimeAudioOutput)]
         user_started = [i for i in items if isinstance(i, RealtimeUserSpeechStarted)]
         user_ended = [i for i in items if isinstance(i, RealtimeUserSpeechEnded)]

--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -183,10 +183,11 @@ class Realtime(realtime.Realtime):
         call this repeatedly with consecutive frames.
 
         Args:
-            audio: PCM audio frame to forward upstream.
+            pcm: PCM audio frame to forward upstream.
             participant: Optional participant information for the audio source.
         """
         # Track current participant for user speech transcription events
+        self._current_participant = participant
         await self.rtc.send_audio_pcm(pcm)
 
     async def close(self):
@@ -262,11 +263,16 @@ class Realtime(realtime.Realtime):
             participant = self._current_participant
             await self.interrupt()
             if participant is not None:
+                # Restore so the matching speech_stopped can emit RealtimeUserSpeechEnded.
+                self._current_participant = participant
                 self._output.send_nowait(
                     RealtimeUserSpeechStarted(participant=participant)
                 )
             self._emit_audio_output_done_event(interrupted=True)
-        elif et == "input_audio_buffer.speech_stopped":
+        elif et == "input_audio_buffer.committed":
+            # Fires in both server_vad and semantic_vad modes when the user's
+            # audio buffer is finalized — i.e. the user's turn ended.
+            # speech_stopped is server_vad-only, so it isn't reliable here.
             self._emit_user_speech_ended()
 
         elif et == "response.output_item.added":


### PR DESCRIPTION
## Why
Fix a few bugs failing the daily integration suite 

## Changes
- `aws.Realtime`: exit early when the event stream ends
- `gemini.Realtime`: update how UserSpeech events are emitted. The previous implementation relied on the events from spec that are not enabled for all projects.
- `openai.Realtime`: store `self._current_participant` on `simple_audio_response()`
