### PR TITLE
fix(agents-core): drop duplicate force-include of CLI templates

### DIFF
--- a/agents-core/pyproject.toml
+++ b/agents-core/pyproject.toml
@@ -136,9 +136,6 @@ raw-options = { root = "..", search_parent_directories = true, fallback_version 
 [tool.hatch.build.targets.wheel]
 packages = ["vision_agents"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"vision_agents/cli/init/templates" = "vision_agents/cli/init/templates"
-
 [tool.hatch.build.targets.sdist]
 include = ["vision_agents"]
 


### PR DESCRIPTION
## Why

Building `agents-core` produced five `UserWarning: Duplicate name` lines, one per Jinja template under `vision_agents/cli/init/templates/`. The cause is that hatchling already packages everything inside `packages = ["vision_agents"]` (including non-`.py` files), so the `[tool.hatch.build.targets.wheel.force-include]` entry pointing at the same directory wrote each template into the wheel zip a second time. Removing it silences the warnings and shrinks the wheel; verified the `.j2` files are still present in the built wheel afterwards.