### PR TITLE
docs(changelog): cut v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# v0.6.1
+# v0.7.0
 
 ## Breaking Changes
 
-### `heygen` plugin removed
+### `heygen` plugin removed (#563)
 
 The `heygen` plugin, deprecated in v0.6.0 (#553), is now removed. Use
 `vision_agents.plugins.liveavatar.Avatar` instead — it targets the same product via the supported LITE-mode integration path.
@@ -10,13 +10,21 @@ The `heygen` plugin, deprecated in v0.6.0 (#553), is now removed. Use
 Three internal events used only by the `heygen` plugin (`LLMResponseChunkEvent`, `LLMResponseCompletedEvent`, `RealtimeAgentSpeechTranscriptionEvent`) were also removed from
 `vision_agents.core.llm.events`.
 
+### Python 3.14 not supported (#573)
+
+The workspace and the `vision-agents init` scaffold now cap `requires-python` at `<3.14`. Python 3.14 has no `scipy 1.15.3` wheels for macOS arm64, so installs fell through to a source build that needs gfortran and failed. Use Python 3.10–3.13.
+
+## Bug Fixes
+
+- **Packaging**: stop double-packing CLI templates into the wheel — `hatchling` already includes the `.j2` files via the `packages` entry, so the extra `force-include` wrote each template twice and triggered `UserWarning: Duplicate name` during builds. (#571)
+
 # v0.6.1
 
 ## Breaking Changes
 
 ### Event types cleanup (#552)
 
-Follow-up to the v0.6.0 inference-pipeline rewrite (#501).  
+Follow-up to the v0.6.0 inference-pipeline rewrite (#501).
 The events that used to carry audio / transcript / turn payloads are gone — that data now flows through
 `Stream[T]` outputs on STT, TTS, LLM, and Realtime. Only lifecycle / notification events remain on the event bus.
 


### PR DESCRIPTION
## Why

Preparing the v0.7.0 release. The top of `CHANGELOG.md` had a duplicate `# v0.6.1` heading covering the `heygen` plugin removal (#563); renamed it to `# v0.7.0` so the release notes match the tag we're about to cut. Also folded in the two other user-facing changes that landed since v0.6.1: the `requires-python < 3.14` cap (#573), which prevents installs from falling through to a source build of `scipy` on Python 3.14, and the CLI-templates wheel duplication fix (#571). The remaining commits on `main` (#574, #575) are dev-deps / lockfile chores and aren't called out.