### PR TITLE
docs(changelog): cut v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,38 @@ Three internal events used only by the `heygen` plugin (`LLMResponseChunkEvent`,
 
 The workspace and the `vision-agents init` scaffold now cap `requires-python` at `<3.14`. Python 3.14 has no `scipy 1.15.3` wheels for macOS arm64, so installs fell through to a source build that needs gfortran and failed. Use Python 3.10–3.13.
 
+### Unified plugin lifecycle via `Component` base class (#578)
+
+`LLM`, `STT`, `TTS`, `TurnDetector`, `EdgeTransport`, `Avatar` and `Processor` now inherit from a new
+`vision_agents.core.base.Component` base, which defines a uniform `start()` / `close()` lifecycle (both default to no-ops; subclasses override what they need).
+
+Concrete shape changes for out-of-tree plugins:
+
+- **`TurnDetector.stop` is renamed to `close`.** Plugins that subclassed `TurnDetector` and overrode `stop()` must rename the override; the agent no longer invokes `stop`. The base classes for vogent and smart_turn turn detectors were migrated in this release.
+- `Processor` and `EdgeTransport` no longer redeclare `close` as `@abstractmethod` — the abstract contract now comes from `Component`. Existing implementations that override `close` keep working unchanged.
+- `Component` inherits from `ABC` and keeps `ABCMeta`, so subclasses can continue to declare their own `@abstractmethod`s.
+
+## New Features
+
+### Faster agent startup via parallel component lifecycle (#578)
+
+`Agent.join()` now starts every component concurrently (`asyncio.gather`) instead of stacking their network connects one after another. On a realistic setup
+(Gemini LLM + ElevenLabs STT + Deepgram TTS + vogent + LemonSlice avatar) this cuts the lifecycle phase of `join()` from **~4.3 s to ~2.4 s (≈45% faster, ~1.9 s saved)**;
+the remaining time is the single slowest component (here, the LemonSlice RTC connect).
+
+Error handling is asymmetric and explicit:
+
+- **Startup is fail-fast.** If any component's `start()` raises, the failure is logged with the component class name, in-flight siblings are cancelled and awaited so no
+  half-open network connects leak, and `agent.join()` re-raises so the agent doesn't run half-initialised.
+- **Shutdown is best-effort.** A failing `close()` is logged via `log_exceptions` and swallowed so the remaining components still get a chance to release resources.
+
+Plugin authors: because lifecycle hooks now run concurrently, components must not assume sibling ordering during `start` / `close`. Audio and video frames are still dispatched to processors in list order.
+
+### Friendlier `vision-agents init` errors (#579)
+
+`vision-agents init` without an agent name now prints a message that says what's missing and shows an example, instead of Click's bare `Missing argument 'NAME'.`. The
+positional argument is renamed `AGENT_NAME` and documented in `--help`.
+
 ## Bug Fixes
 
 - **Packaging**: stop double-packing CLI templates into the wheel — `hatchling` already includes the `.j2` files via the `packages` entry, so the extra `force-include` wrote each template twice and triggered `UserWarning: Duplicate name` during builds. (#571)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# v0.6.1
+# v0.6.2
 
 ## Breaking Changes
 
-### `heygen` plugin removed
+### `heygen` plugin removed (#563)
 
 The `heygen` plugin, deprecated in v0.6.0 (#553), is now removed. Use
 `vision_agents.plugins.liveavatar.Avatar` instead — it targets the same product via the supported LITE-mode integration path.
@@ -10,13 +10,21 @@ The `heygen` plugin, deprecated in v0.6.0 (#553), is now removed. Use
 Three internal events used only by the `heygen` plugin (`LLMResponseChunkEvent`, `LLMResponseCompletedEvent`, `RealtimeAgentSpeechTranscriptionEvent`) were also removed from
 `vision_agents.core.llm.events`.
 
+### Python 3.14 not supported (#573)
+
+The workspace and the `vision-agents init` scaffold now cap `requires-python` at `<3.14`. Python 3.14 has no `scipy 1.15.3` wheels for macOS arm64, so installs fell through to a source build that needs gfortran and failed. Use Python 3.10–3.13.
+
+## Bug Fixes
+
+- **Packaging**: stop double-packing CLI templates into the wheel — `hatchling` already includes the `.j2` files via the `packages` entry, so the extra `force-include` wrote each template twice and triggered `UserWarning: Duplicate name` during builds. (#571)
+
 # v0.6.1
 
 ## Breaking Changes
 
 ### Event types cleanup (#552)
 
-Follow-up to the v0.6.0 inference-pipeline rewrite (#501).  
+Follow-up to the v0.6.0 inference-pipeline rewrite (#501).
 The events that used to carry audio / transcript / turn payloads are gone — that data now flows through
 `Stream[T]` outputs on STT, TTS, LLM, and Realtime. Only lifecycle / notification events remain on the event bus.
 


### PR DESCRIPTION
## Why

Preparing the v0.6.2 release. The top of `CHANGELOG.md` had a duplicate `# v0.6.1` heading covering the `heygen` plugin removal (#563); renamed it to `# v0.6.2` so the release notes match the tag we're about to cut. Also folded in the two other user-facing changes that landed since v0.6.1: the `requires-python < 3.14` cap (#573), which prevents installs from falling through to a source build of `scipy` on Python 3.14, and the CLI-templates wheel duplication fix (#571). The remaining commits on `main` (#574, #575) are dev-deps / lockfile chores and aren't called out.