### PR TITLE
refactor(cli/init): friendlier missing-arg error and clearer help

### DIFF
--- a/agents-core/vision_agents/cli/init/command.py
+++ b/agents-core/vision_agents/cli/init/command.py
@@ -1,50 +1,46 @@
 """``vision-agents init`` — scaffold a new agent project."""
 
-import tempfile
 from pathlib import Path
 
 import click
 from jinja2 import TemplateError
 
 from vision_agents.cli.errors import CliError
-from vision_agents.cli.init.scaffold import scaffold
+from vision_agents.cli.init.scaffold import create_project
 from vision_agents.cli.init.uv import install_dependencies
 
 
-@click.command("init", help="Scaffold a new agent project from a template.")
-@click.argument("name")
+@click.command(
+    "init",
+    help=(
+        "Create a new agent project.\n\n"
+        "\b\n"
+        "Arguments:\n"
+        "  AGENT_NAME  Name for the new agent. Used as the directory and\n"
+        "              Python project name, e.g. my-agent."
+    ),
+)
+@click.argument("name", required=False, metavar="AGENT_NAME")
 @click.option(
     "--no-install",
     is_flag=True,
     help="Do not run 'uv sync' after generating the project.",
 )
-def init_cmd(name: str, no_install: bool) -> None:
+def init_cmd(name: str | None, no_install: bool) -> None:
+    if not name:
+        raise CliError(
+            "agent name is required.\n\nExample: vision-agents init my-agent"
+        )
     install = not no_install
     target = Path(name).resolve()
-    if target.exists():
-        raise CliError(f"{target} already exists")
 
-    # Scaffold into a staging dir on the same filesystem, then rename
-    # atomically so partial output is never observable at `target` and
-    # we never delete a path we didn't create.
     try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        tmp_ctx = tempfile.TemporaryDirectory(
-            prefix=f".{target.name}-init-", dir=target.parent
-        )
-    except OSError as err:
-        raise CliError(f"failed to prepare scaffold target {target}: {err}") from err
+        create_project(target.name, target)
+    except FileExistsError:
+        raise CliError(f"{target} already exists") from None
+    except (OSError, TemplateError) as err:
+        raise CliError(f"failed to create project at {target}: {err}") from err
 
-    with tmp_ctx as tmp:
-        staging = Path(tmp) / target.name
-        try:
-            scaffold(target.name, staging)
-        except (OSError, TemplateError) as err:
-            raise CliError(f"failed to scaffold {target}: {err}") from err
-        try:
-            staging.rename(target)
-        except OSError as err:
-            raise CliError(f"failed to finalize {target}: {err}") from err
     click.echo(f"{click.style('Created', fg='green', bold=True)} {target}")
 
     if install:

--- a/agents-core/vision_agents/cli/init/scaffold.py
+++ b/agents-core/vision_agents/cli/init/scaffold.py
@@ -1,5 +1,6 @@
 """Jinja template rendering for ``vision-agents init``."""
 
+import tempfile
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
@@ -22,7 +23,31 @@ def jinja_env() -> Environment:
     )
 
 
-def scaffold(project_name: str, target: Path) -> None:
+def create_project(name: str, target: Path) -> None:
+    """Create a new agent project at ``target`` named ``name``.
+
+    Renders into a sibling staging dir on the same filesystem, then renames
+    atomically so partial output is never observable at ``target`` and we
+    never delete a path we didn't create.
+
+    Raises:
+        FileExistsError: if ``target`` already exists.
+        OSError: on filesystem failures.
+        jinja2.TemplateError: on template rendering failures.
+    """
+    if target.exists():
+        raise FileExistsError(target)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix=f".{target.name}-init-", dir=target.parent
+    ) as tmp:
+        staging = Path(tmp) / target.name
+        _render_templates(name, staging)
+        staging.rename(target)
+
+
+def _render_templates(project_name: str, target: Path) -> None:
     target.mkdir(parents=True)
     env = jinja_env()
     context = {"project_name": project_name}

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -39,6 +39,12 @@ class TestInitCommand:
         assert result.exit_code != 0
         assert "already exists" in result.output
 
+    def test_errors_with_friendly_message_when_name_missing(self, runner: CliRunner):
+        result = runner.invoke(init_cmd, [])
+        assert result.exit_code != 0
+        assert "agent name is required" in result.output
+        assert "vision-agents init my-agent" in result.output
+
 
 class TestAgentCommand:
     @pytest.fixture


### PR DESCRIPTION
## Why

`vision-agents init` without a name printed Click's generic `Error: Missing argument 'NAME'.`, which doesn't tell users what `NAME` means or how to fix it. `--help` was similarly terse: `[NAME]` with no description, and the summary "Scaffold a new agent project from a template." used SDK-developer vocabulary.

This PR makes the command friendlier for end users and tidies the internal structure so the Click command stays an orchestrator.

## Changes

- Replace the generic missing-argument error with `agent name is required.` plus an example invocation.
- Rename the metavar `NAME` → `AGENT_NAME` and document it under an `Arguments:` block in `--help`.
- Reword the command summary to "Create a new agent project." (drop "Scaffold" / "from a template").
- Move project creation (staging dir + atomic rename + error mapping) from `command.py` into `scaffold.create_project`. Old `scaffold()` becomes private `_render_templates()`.
- Add a test for the friendly missing-name error.