### PR TITLE
test(agents-core): add unit tests for log_exceptions

### DIFF
--- a/tests/test_utils/test_exceptions.py
+++ b/tests/test_utils/test_exceptions.py
@@ -6,11 +6,13 @@ import pytest
 from vision_agents.core.utils.exceptions import log_exceptions
 
 
-logger = logging.getLogger("test_log_exceptions")
+logger = logging.getLogger(__name__)
 
 
 class TestLogExceptions:
-    def test_catches_exception_by_default(self, caplog):
+    def test_catches_exception_by_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """A subclass of Exception inside the block is caught and logged, not propagated."""
         with caplog.at_level(logging.ERROR):
             with log_exceptions(logger, "boom happened"):
@@ -19,20 +21,26 @@ class TestLogExceptions:
         assert any("boom happened" in r.message for r in caplog.records)
         assert any(r.exc_info is not None for r in caplog.records)
 
-    def test_does_not_log_when_block_completes_cleanly(self, caplog):
+    def test_does_not_log_when_block_completes_cleanly(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         with caplog.at_level(logging.ERROR):
             with log_exceptions(logger, "should not appear"):
                 pass
         assert not any("should not appear" in r.message for r in caplog.records)
 
-    def test_reraise_propagates_after_logging(self, caplog):
+    def test_reraise_propagates_after_logging(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         with caplog.at_level(logging.ERROR):
             with pytest.raises(ValueError, match="boom"):
                 with log_exceptions(logger, "boom happened", reraise=True):
                     raise ValueError("boom")
         assert any("boom happened" in r.message for r in caplog.records)
 
-    def test_only_catches_specified_exception_types(self, caplog):
+    def test_only_catches_specified_exception_types(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Exceptions not in the configured tuple must propagate."""
         with caplog.at_level(logging.ERROR):
             with pytest.raises(KeyError):
@@ -40,13 +48,17 @@ class TestLogExceptions:
                     raise KeyError("not_caught")
         assert not any("would log" in r.message for r in caplog.records)
 
-    def test_catches_any_specified_exception_type(self, caplog):
+    def test_catches_any_specified_exception_type(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         with caplog.at_level(logging.ERROR):
             with log_exceptions(logger, "caught it", ValueError, KeyError):
                 raise KeyError("inner")
         assert any("caught it" in r.message for r in caplog.records)
 
-    def test_base_exception_subclasses_propagate_by_default(self, caplog):
+    def test_base_exception_subclasses_propagate_by_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Default filter is ``Exception``; ``BaseException`` subclasses must pass through.
 
         This is load-bearing for callers that rely on ``CancelledError`` /
@@ -58,7 +70,9 @@ class TestLogExceptions:
                     raise KeyboardInterrupt
         assert not any("should not log" in r.message for r in caplog.records)
 
-    def test_cancelled_error_propagates_by_default(self, caplog):
+    def test_cancelled_error_propagates_by_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         with caplog.at_level(logging.ERROR):
             with pytest.raises(asyncio.CancelledError):
                 with log_exceptions(logger, "should not log"):

--- a/tests/test_utils/test_exceptions.py
+++ b/tests/test_utils/test_exceptions.py
@@ -46,17 +46,21 @@ class TestLogExceptions:
                 raise KeyError("inner")
         assert any("caught it" in r.message for r in caplog.records)
 
-    def test_base_exception_subclasses_propagate_by_default(self):
+    def test_base_exception_subclasses_propagate_by_default(self, caplog):
         """Default filter is ``Exception``; ``BaseException`` subclasses must pass through.
 
         This is load-bearing for callers that rely on ``CancelledError`` /
         ``KeyboardInterrupt`` reaching outer scopes during cancellation.
         """
-        with pytest.raises(KeyboardInterrupt):
-            with log_exceptions(logger, "should not log"):
-                raise KeyboardInterrupt
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(KeyboardInterrupt):
+                with log_exceptions(logger, "should not log"):
+                    raise KeyboardInterrupt
+        assert not any("should not log" in r.message for r in caplog.records)
 
-    def test_cancelled_error_propagates_by_default(self):
-        with pytest.raises(asyncio.CancelledError):
-            with log_exceptions(logger, "should not log"):
-                raise asyncio.CancelledError()
+    def test_cancelled_error_propagates_by_default(self, caplog):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(asyncio.CancelledError):
+                with log_exceptions(logger, "should not log"):
+                    raise asyncio.CancelledError()
+        assert not any("should not log" in r.message for r in caplog.records)

--- a/tests/test_utils/test_exceptions.py
+++ b/tests/test_utils/test_exceptions.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+
+import pytest
+
+from vision_agents.core.utils.exceptions import log_exceptions
+
+
+logger = logging.getLogger("test_log_exceptions")
+
+
+class TestLogExceptions:
+    def test_catches_exception_by_default(self, caplog):
+        """A subclass of Exception inside the block is caught and logged, not propagated."""
+        with caplog.at_level(logging.ERROR):
+            with log_exceptions(logger, "boom happened"):
+                raise ValueError("boom")
+        # Reaching this line means the exception was swallowed.
+        assert any("boom happened" in r.message for r in caplog.records)
+        assert any(r.exc_info is not None for r in caplog.records)
+
+    def test_does_not_log_when_block_completes_cleanly(self, caplog):
+        with caplog.at_level(logging.ERROR):
+            with log_exceptions(logger, "should not appear"):
+                pass
+        assert not any("should not appear" in r.message for r in caplog.records)
+
+    def test_reraise_propagates_after_logging(self, caplog):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ValueError, match="boom"):
+                with log_exceptions(logger, "boom happened", reraise=True):
+                    raise ValueError("boom")
+        assert any("boom happened" in r.message for r in caplog.records)
+
+    def test_only_catches_specified_exception_types(self, caplog):
+        """Exceptions not in the configured tuple must propagate."""
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(KeyError):
+                with log_exceptions(logger, "would log", ValueError):
+                    raise KeyError("not_caught")
+        assert not any("would log" in r.message for r in caplog.records)
+
+    def test_catches_any_specified_exception_type(self, caplog):
+        with caplog.at_level(logging.ERROR):
+            with log_exceptions(logger, "caught it", ValueError, KeyError):
+                raise KeyError("inner")
+        assert any("caught it" in r.message for r in caplog.records)
+
+    def test_base_exception_subclasses_propagate_by_default(self):
+        """Default filter is ``Exception``; ``BaseException`` subclasses must pass through.
+
+        This is load-bearing for callers that rely on ``CancelledError`` /
+        ``KeyboardInterrupt`` reaching outer scopes during cancellation.
+        """
+        with pytest.raises(KeyboardInterrupt):
+            with log_exceptions(logger, "should not log"):
+                raise KeyboardInterrupt
+
+    def test_cancelled_error_propagates_by_default(self):
+        with pytest.raises(asyncio.CancelledError):
+            with log_exceptions(logger, "should not log"):
+                raise asyncio.CancelledError()


### PR DESCRIPTION
## Why

`log_exceptions` is used in eight places across the codebase but has no direct test coverage. Callers (in particular the lifecycle error handling in `Agent._apply`) rely on a specific contract — silently changing what gets caught would break those callers without anything failing.

Pin down the contract before it can drift.

## Changes

New `tests/test_utils/test_exceptions.py` covering:

- catches `Exception` by default and logs via `logger.exception`
- `reraise=True` propagates after logging
- only catches the configured exception tuple; others propagate
- `BaseException` subclasses outside `Exception` (`KeyboardInterrupt`, `asyncio.CancelledError`) pass through unchanged — load-bearing for cancellation flows