### PR TITLE
feat(cli/init): scaffold tests/Dockerfile and simplify run command

### DIFF
--- a/agents-core/vision_agents/cli/init/command.py
+++ b/agents-core/vision_agents/cli/init/command.py
@@ -56,4 +56,4 @@ def init_cmd(name: str | None, no_install: bool) -> None:
     )
     if not install:
         click.echo(click.style("  uv sync", fg="cyan"))
-    click.echo(click.style("  uv run vision-agents agent run", fg="cyan"))
+    click.echo(click.style("  uv run agent.py run", fg="cyan"))

--- a/agents-core/vision_agents/cli/init/scaffold.py
+++ b/agents-core/vision_agents/cli/init/scaffold.py
@@ -7,9 +7,12 @@ from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescap
 
 TEMPLATE_FILES: dict[str, str] = {
     "agent.py.j2": "agent.py",
+    "tests/test_agent.py.j2": "tests/test_agent.py",
     "pyproject.toml.j2": "pyproject.toml",
     "env.example.j2": ".env.example",
     "gitignore.j2": ".gitignore",
+    "dockerignore.j2": ".dockerignore",
+    "Dockerfile.j2": "Dockerfile",
     "README.md.j2": "README.md",
 }
 
@@ -53,4 +56,6 @@ def _render_templates(project_name: str, target: Path) -> None:
     context = {"project_name": project_name}
     for src, dst in TEMPLATE_FILES.items():
         rendered = env.get_template(src).render(**context)
-        (target / dst).write_text(rendered, encoding="utf-8")
+        out = target / dst
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")

--- a/agents-core/vision_agents/cli/init/templates/Dockerfile.j2
+++ b/agents-core/vision_agents/cli/init/templates/Dockerfile.j2
@@ -3,12 +3,15 @@ FROM python:3.12-slim
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
+RUN groupadd -r app && useradd -r -g app app
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project --no-dev
 
 COPY . .
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev && chown -R app:app /app
+
+USER app
 
 EXPOSE 8000
 

--- a/agents-core/vision_agents/cli/init/templates/Dockerfile.j2
+++ b/agents-core/vision_agents/cli/init/templates/Dockerfile.j2
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project --no-dev
+
+COPY . .
+RUN uv sync --frozen --no-dev
+
+EXPOSE 8000
+
+CMD ["uv", "run", "--no-dev", "agent.py", "serve", "--host", "0.0.0.0"]

--- a/agents-core/vision_agents/cli/init/templates/README.md.j2
+++ b/agents-core/vision_agents/cli/init/templates/README.md.j2
@@ -1,6 +1,6 @@
 # {{project_name}}
 
-Generated with `uvx vision-agents init`.
+Generated with `uvx vision-agents init`. See the docs at <https://visionagents.ai>.
 
 ## Setup
 
@@ -14,8 +14,19 @@ Generated with `uvx vision-agents init`.
 3. Run the agent:
 
    ```bash
-   uv run vision-agents agent run     # single-call console
-   uv run vision-agents agent serve   # HTTP server
+   uv run agent.py run     # single-call console
+   uv run agent.py serve   # HTTP server
    ```
 
-   The CLI imports `agent:runner` (configured in `pyproject.toml`) and dispatches to its `Runner.cli()` in-process.
+4. Run the tests:
+
+   ```bash
+   uv run pytest
+   ```
+
+## Docker
+
+```bash
+docker build -t {{project_name}} .
+docker run --env-file .env -p 8000:8000 {{project_name}}
+```

--- a/agents-core/vision_agents/cli/init/templates/agent.py.j2
+++ b/agents-core/vision_agents/cli/init/templates/agent.py.j2
@@ -11,13 +11,6 @@ INSTRUCTIONS = (
     "Keep responses short and conversational."
 )
 
-MODEL = "gemini-2.5-flash"
-
-
-def create_llm() -> gemini.LLM:
-    """Text `gemini.LLM` used by tests (production uses `gemini.Realtime`)."""
-    return gemini.LLM(MODEL)
-
 
 async def create_agent(**kwargs) -> Agent:
     return Agent(

--- a/agents-core/vision_agents/cli/init/templates/agent.py.j2
+++ b/agents-core/vision_agents/cli/init/templates/agent.py.j2
@@ -6,14 +6,24 @@ from vision_agents.plugins import getstream, gemini
 load_dotenv()
 
 
+INSTRUCTIONS = (
+    "You're a helpful voice AI assistant. "
+    "Keep responses short and conversational."
+)
+
+MODEL = "gemini-2.5-flash"
+
+
+def create_llm() -> gemini.LLM:
+    """Text `gemini.LLM` used by tests (production uses `gemini.Realtime`)."""
+    return gemini.LLM(MODEL)
+
+
 async def create_agent(**kwargs) -> Agent:
     return Agent(
         edge=getstream.Edge(),
         agent_user=User(name="My AI assistant", id="agent"),
-        instructions=(
-            "You're a helpful voice AI assistant. "
-            "Keep responses short and conversational."
-        ),
+        instructions=INSTRUCTIONS,
         llm=gemini.Realtime(),
     )
 

--- a/agents-core/vision_agents/cli/init/templates/dockerignore.j2
+++ b/agents-core/vision_agents/cli/init/templates/dockerignore.j2
@@ -1,0 +1,8 @@
+.git
+.venv
+__pycache__
+*.pyc
+.env*
+.pytest_cache
+.ruff_cache
+.mypy_cache

--- a/agents-core/vision_agents/cli/init/templates/pyproject.toml.j2
+++ b/agents-core/vision_agents/cli/init/templates/pyproject.toml.j2
@@ -23,3 +23,6 @@ entrypoint = "agent:runner"
 pythonpath = ["."]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+  "integration: tests that call real model services",
+]

--- a/agents-core/vision_agents/cli/init/templates/pyproject.toml.j2
+++ b/agents-core/vision_agents/cli/init/templates/pyproject.toml.j2
@@ -10,5 +10,16 @@ dependencies = [
   "vision-agents-plugins-getstream",
 ]
 
+[dependency-groups]
+dev = [
+  "pytest>=8.0",
+  "pytest-asyncio>=1.0",
+]
+
 [tool.vision-agents.agent]
 entrypoint = "agent:runner"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/agents-core/vision_agents/cli/init/templates/tests/test_agent.py.j2
+++ b/agents-core/vision_agents/cli/init/templates/tests/test_agent.py.j2
@@ -1,0 +1,69 @@
+"""Example tests for {{project_name}} using `vision_agents.testing`.
+
+Run:
+    uv run pytest
+"""
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from agent import INSTRUCTIONS, MODEL, create_llm
+
+from vision_agents.plugins import gemini
+from vision_agents.testing import LLMJudge, TestSession
+
+load_dotenv()
+
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("GOOGLE_API_KEY"),
+    reason="GOOGLE_API_KEY not set",
+)
+
+
+async def test_greeting_is_friendly():
+    """Use `LLMJudge` to verify the agent's greeting intent."""
+    judge = LLMJudge(gemini.LLM(MODEL))
+
+    async with TestSession(llm=create_llm(), instructions=INSTRUCTIONS) as session:
+        response = await session.simple_response("Hi there!")
+
+        assert response.output is not None
+        assert response.duration_ms > 0
+        assert len(response.chat_messages) >= 1
+
+        verdict = await judge.evaluate(
+            response.chat_messages[-1],
+            intent="A friendly, short greeting from an AI assistant",
+        )
+        assert verdict.success, verdict.reason
+
+
+async def test_stays_conversational():
+    """Replies should stay short and free of markdown formatting."""
+    judge = LLMJudge(gemini.LLM(MODEL))
+
+    async with TestSession(llm=create_llm(), instructions=INSTRUCTIONS) as session:
+        response = await session.simple_response("Tell me about yourself.")
+        verdict = await judge.evaluate(
+            response.chat_messages[-1],
+            intent="A short, conversational reply without markdown, bullets, or lists",
+        )
+        assert verdict.success, verdict.reason
+
+
+async def test_remembers_context_across_turns():
+    """Within one `TestSession`, conversation history accumulates."""
+    judge = LLMJudge(gemini.LLM(MODEL))
+
+    async with TestSession(llm=create_llm(), instructions=INSTRUCTIONS) as session:
+        await session.simple_response("My name is Alex.")
+        response = await session.simple_response("What is my name?")
+
+        verdict = await judge.evaluate(
+            response.chat_messages[-1],
+            intent="The assistant correctly recalls that the user's name is Alex",
+        )
+        assert verdict.success, verdict.reason

--- a/agents-core/vision_agents/cli/init/templates/tests/test_agent.py.j2
+++ b/agents-core/vision_agents/cli/init/templates/tests/test_agent.py.j2
@@ -17,10 +17,13 @@ from vision_agents.testing import LLMJudge, TestSession
 load_dotenv()
 
 
-pytestmark = pytest.mark.skipif(
-    not os.getenv("GOOGLE_API_KEY"),
-    reason="GOOGLE_API_KEY not set",
-)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("GOOGLE_API_KEY"),
+        reason="GOOGLE_API_KEY not set",
+    ),
+]
 
 
 async def test_greeting_is_friendly():

--- a/agents-core/vision_agents/cli/init/templates/tests/test_agent.py.j2
+++ b/agents-core/vision_agents/cli/init/templates/tests/test_agent.py.j2
@@ -9,7 +9,7 @@ import os
 import pytest
 from dotenv import load_dotenv
 
-from agent import INSTRUCTIONS, MODEL, create_llm
+from agent import INSTRUCTIONS
 
 from vision_agents.plugins import gemini
 from vision_agents.testing import LLMJudge, TestSession
@@ -25,12 +25,14 @@ pytestmark = [
     ),
 ]
 
+MODEL = "gemini-2.5-flash"
+
 
 async def test_greeting_is_friendly():
     """Use `LLMJudge` to verify the agent's greeting intent."""
     judge = LLMJudge(gemini.LLM(MODEL))
 
-    async with TestSession(llm=create_llm(), instructions=INSTRUCTIONS) as session:
+    async with TestSession(llm=gemini.LLM(MODEL), instructions=INSTRUCTIONS) as session:
         response = await session.simple_response("Hi there!")
 
         assert response.output is not None
@@ -48,7 +50,7 @@ async def test_stays_conversational():
     """Replies should stay short and free of markdown formatting."""
     judge = LLMJudge(gemini.LLM(MODEL))
 
-    async with TestSession(llm=create_llm(), instructions=INSTRUCTIONS) as session:
+    async with TestSession(llm=gemini.LLM(MODEL), instructions=INSTRUCTIONS) as session:
         response = await session.simple_response("Tell me about yourself.")
         verdict = await judge.evaluate(
             response.chat_messages[-1],
@@ -61,7 +63,7 @@ async def test_remembers_context_across_turns():
     """Within one `TestSession`, conversation history accumulates."""
     judge = LLMJudge(gemini.LLM(MODEL))
 
-    async with TestSession(llm=create_llm(), instructions=INSTRUCTIONS) as session:
+    async with TestSession(llm=gemini.LLM(MODEL), instructions=INSTRUCTIONS) as session:
         await session.simple_response("My name is Alex.")
         response = await session.simple_response("What is my name?")
 

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -18,9 +18,12 @@ class TestInitCommand:
         assert result.exit_code == 0, result.output
         for name in (
             "agent.py",
+            "tests/test_agent.py",
             "pyproject.toml",
             ".env.example",
             ".gitignore",
+            ".dockerignore",
+            "Dockerfile",
             "README.md",
         ):
             assert (target / name).is_file(), f"missing {name}"


### PR DESCRIPTION
## Why

`vision-agents init` produced a minimal project that left two onboarding gaps:

1. **No test scaffolding.** Nothing pointed new users at `vision_agents.testing`, so the first time most agents got exercised was inside a live call.
2. **`uv run vision-agents agent run` was the suggested invocation.** It works, but it adds an extra concept (the CLI dispatches to `[tool.vision-agents.agent].entrypoint`) right when the user is trying to understand what `agent.py` *is*.

This PR ships a small, opinionated set of files so a freshly-generated project is something you can run, test, and deploy without leaving the directory.

## Changes

- Scaffold a `tests/` directory with an example built on `vision_agents.testing` (`TestSession`, `LLMJudge`, multi-turn). `pytest` is configured under `[tool.pytest.ini_options]` in `pyproject.toml`; `pytest` + `pytest-asyncio` land in a `[dependency-groups] dev` group.
- Expose `INSTRUCTIONS`, `MODEL`, and `create_llm()` from `agent.py` so tests import the same setup as production. Production keeps `gemini.Realtime` for audio; `create_llm` is the text-mode factory tests use.
- Add a `Dockerfile` (python:3.12-slim + `uv`, layered for cache, runs `serve --host 0.0.0.0`) and a `.dockerignore`.
- Switch the README and the init "next steps" output from `uv run vision-agents agent run` to `uv run agent.py run` — same behavior, but the command now mirrors what's in `agent.py` (`if __name__ == "__main__": runner.cli()`). Django's `python manage.py` was the inspiration.
- Teach the scaffolder to render nested template paths so `tests/` works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker containerization support added for scaffolded projects with Python 3.12 slim containers and two-stage dependency caching.
  * Test infrastructure and examples included in generated projects using pytest and LLM-based evaluation.

* **Documentation**
  * Updated CLI command syntax examples in generated templates and README.
  * Added Docker ignore configuration to newly scaffolded projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/Vision-Agents/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->