### PR TITLE
chore: Python 3.14 support across the workspace + per-version compat CI

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -1,4 +1,4 @@
-name: Python compat
+name: Python compatibility check
 on:
   push:
     branches: [ "main" ]
@@ -16,7 +16,7 @@ on:
       - '.github/workflows/python-versions.yml'
 
 concurrency:
-  group: python-compat-${{ github.workflow }}-${{ github.ref }}
+  group: python-compatibility-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -1,0 +1,36 @@
+name: Python compat
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '**/pyproject.toml'
+      - 'uv.lock'
+      - 'dev.py'
+      - '.github/workflows/python-versions.yml'
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - '**/pyproject.toml'
+      - 'uv.lock'
+      - 'dev.py'
+      - '.github/workflows/python-versions.yml'
+
+concurrency:
+  group: python-compat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: Resolve on Python ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install dependencies
+        uses: ./.github/actions/python-uv-setup
+      - name: Resolve every workspace member on Python ${{ matrix.python }}
+        run: uv run --no-sync dev.py check-python-versions ${{ matrix.python }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 `agents-core` and every plugin except `kokoro`, `smart_turn`, and `vogent` now advertise Python 3.14 support. `kokoro` and `smart_turn` pin `numpy<2.3`, which conflicts with `getstream[webrtc]`'s `numpy>=2.3.2` on 3.14. `vogent` pulls `vogent-turn==0.1.1`, which pins `onnxruntime-gpu==1.22.*` on Linux/Windows x86_64, and that has no `cp314` wheels.
 
-Until a new `getstream` release ships, the workspace temporarily pins `getstream` to a `main` commit via `[tool.uv.sources]`.
+Bumps the minimum `getstream` to `>=3.4.0` — that's the first release containing the Python 3.14 wheel-availability fix (https://github.com/GetStream/stream-py/pull/253).
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Python 3.14 support
 
-`agents-core` and every plugin except `kokoro` and `smart_turn` now advertise Python 3.14 support. Those two stay capped at `<3.14` because they pin `numpy<2.3`, which conflicts with the `numpy>=2.3.2` constraint that `getstream[webrtc]` carries on 3.14.
+`agents-core` and every plugin except `kokoro`, `smart_turn`, and `vogent` now advertise Python 3.14 support. `kokoro` and `smart_turn` pin `numpy<2.3`, which conflicts with `getstream[webrtc]`'s `numpy>=2.3.2` on 3.14. `vogent` pulls `vogent-turn==0.1.1`, which pins `onnxruntime-gpu==1.22.*` on Linux/Windows x86_64, and that has no `cp314` wheels.
 
 Until a new `getstream` release ships, the workspace temporarily pins `getstream` to a `main` commit via `[tool.uv.sources]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-### Python 3.14 support
+### Python 3.14 support (#582)
 
 `agents-core` and every plugin except `kokoro`, `smart_turn`, and `vogent` now advertise Python 3.14 support. `kokoro` and `smart_turn` pin `numpy<2.3`, which conflicts with `getstream[webrtc]`'s `numpy>=2.3.2` on 3.14. `vogent` pulls `vogent-turn==0.1.1`, which pins `onnxruntime-gpu==1.22.*` on Linux/Windows x86_64, and that has no `cp314` wheels.
 
@@ -10,7 +10,7 @@ Until a new `getstream` release ships, the workspace temporarily pins `getstream
 
 ## Bug Fixes
 
-### `smart_turn` and `vogent` `requires-python` raised to `>=3.11`
+### `smart_turn` and `vogent` `requires-python` raised to `>=3.11` (#582)
 
 Both plugins depend on `onnxruntime>=1.24.3`, which has no `cp310` wheels. Their metadata previously advertised `>=3.10`, so a 3.10 install would fail at resolution time. Bumping to `>=3.11` makes the published metadata honest.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Unreleased
+
+## New Features
+
+### Python 3.14 support
+
+`agents-core` and every plugin except `kokoro` and `smart_turn` now advertise Python 3.14 support. Those two stay capped at `<3.14` because they pin `numpy<2.3`, which conflicts with the `numpy>=2.3.2` constraint that `getstream[webrtc]` carries on 3.14.
+
+Until a new `getstream` release ships, the workspace temporarily pins `getstream` to a `main` commit via `[tool.uv.sources]`.
+
+## Bug Fixes
+
+### `smart_turn` and `vogent` `requires-python` raised to `>=3.11`
+
+Both plugins depend on `onnxruntime>=1.24.3`, which has no `cp310` wheels. Their metadata previously advertised `>=3.10`, so a 3.10 install would fail at resolution time. Bumping to `>=3.11` makes the published metadata honest.
+
 # v0.6.1
 
 ## Breaking Changes
@@ -16,7 +32,7 @@ Three internal events used only by the `heygen` plugin (`LLMResponseChunkEvent`,
 
 ### Event types cleanup (#552)
 
-Follow-up to the v0.6.0 inference-pipeline rewrite (#501).  
+Follow-up to the v0.6.0 inference-pipeline rewrite (#501).
 The events that used to carry audio / transcript / turn payloads are gone — that data now flows through
 `Stream[T]` outputs on STT, TTS, LLM, and Realtime. Only lifecycle / notification events remain on the event bus.
 

--- a/agents-core/pyproject.toml
+++ b/agents-core/pyproject.toml
@@ -15,11 +15,12 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "getstream[webrtc,telemetry]>=3.3.4,<4",
     "aiortc>=1.14.0,<1.15.0",

--- a/agents-core/pyproject.toml
+++ b/agents-core/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "getstream[webrtc,telemetry]>=3.3.4,<4",
+    "getstream[webrtc,telemetry]>=3.4.0,<4",
     "aiortc>=1.14.0,<1.15.0",
     "av>=14.2.0, <17",
     "python-dotenv>=1.1.1",

--- a/dev.py
+++ b/dev.py
@@ -10,6 +10,7 @@ import os
 import shlex
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import NamedTuple, Optional
 
@@ -17,7 +18,9 @@ import click
 import setuptools
 import toml
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
+from packaging.version import Version
 
 CORE_EXTRAS_ALL_SECTION = "all-plugins"
 CORE_EXTRAS_DEV_SECTION = "dev"
@@ -202,6 +205,70 @@ def validate_extra_dependencies():
             f'plugin_name = ["vision-agents-plugins-plugin-name"]'
         )
     return None
+
+
+def _workspace_members() -> list[Path]:
+    repo = Path(__file__).resolve().parent
+    with open(repo / "pyproject.toml", "r") as f:
+        data = toml.load(f)
+    members = data.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+    return [repo / m for m in members]
+
+
+def _requires_python(pyproj: Path) -> str:
+    with open(pyproj, "r") as f:
+        data = toml.load(f)
+    return data.get("project", {}).get("requires-python", "")
+
+
+@cli.command(name="check-python-versions")
+@click.argument("python_version")
+def check_python_versions(python_version: str):
+    """Verify every workspace member resolves on a target Python version.
+
+    For each workspace member (agents-core + every plugins/*), skip if its
+    `requires-python` excludes the target, otherwise call `uv pip compile`
+    against its pyproject.toml. Runs from a tmp dir so workspace-level
+    `[tool.uv]` overrides are bypassed; `[tool.uv.sources]` from the parent
+    workspace still applies because uv walks up from the package path.
+    """
+    target = Version(python_version)
+    ok: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    failed: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="py-compat-") as td:
+        cwd = Path(td)
+        for member in _workspace_members():
+            pyproj = member / "pyproject.toml"
+            req = _requires_python(pyproj)
+            if req and not SpecifierSet(req).contains(target, prereleases=True):
+                skipped.append((member.name, req))
+                continue
+            click.echo(f"::group::{member.name} on Python {python_version}")
+            result = subprocess.run(
+                ["uv", "pip", "compile", str(pyproj), "-p", python_version, "--quiet"],
+                cwd=cwd,
+                text=True,
+                capture_output=True,
+            )
+            sys.stdout.write(result.stdout)
+            sys.stderr.write(result.stderr)
+            click.echo("::endgroup::")
+            if result.returncode == 0:
+                ok.append(member.name)
+            else:
+                failed.append(member.name)
+
+    click.echo(f"\n=== Python {python_version} summary ===")
+    click.echo(f"OK ({len(ok)}): {', '.join(ok) or '-'}")
+    if skipped:
+        click.echo(f"Skipped ({len(skipped)}):")
+        for name, req in skipped:
+            click.echo(f"  {name} (requires {req})")
+    if failed:
+        click.echo(f"\nFAILED ({len(failed)}): {', '.join(failed)}")
+        sys.exit(1)
 
 
 @cli.command()

--- a/examples/01_simple_agent_example/pyproject.toml
+++ b/examples/01_simple_agent_example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "simple-agents-example"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 
 # Dependencies that the example actually uses
 dependencies = [

--- a/examples/02_golf_coach_example/pyproject.toml
+++ b/examples/02_golf_coach_example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vision-agents-golf"
 version = "0.0.0"
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.13"
 
 # put only what this example needs
 dependencies = [

--- a/examples/03_phone_and_rag_example/pyproject.toml
+++ b/examples/03_phone_and_rag_example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vision-agents-phone"
 version = "0.0.0"
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.13"
 
 # put only what this example needs
 dependencies = [

--- a/plugins/anam/example/pyproject.toml
+++ b/plugins/anam/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "anam-avatar-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
     "python-dotenv>=1.0",

--- a/plugins/anam/pyproject.toml
+++ b/plugins/anam/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Anam avatar plugin for Vision Agents"
 readme = "README.md"
 keywords = ["anam", "avatars", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/anthropic/pyproject.toml
+++ b/plugins/anthropic/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Anthropic/Claude LLM integration for Vision Agents"
 readme = "README.md"
 keywords = ["anthropic", "claude", "LLM", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/assemblyai/example/pyproject.toml
+++ b/plugins/assemblyai/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "assemblyai-stt-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/assemblyai/pyproject.toml
+++ b/plugins/assemblyai/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "AssemblyAI streaming STT integration for Vision Agents"
 readme = "README.md"
 keywords = ["assemblyai", "STT", "speech-to-text", "transcription", "streaming", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/aws/example/pyproject.toml
+++ b/plugins/aws/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aws-bedrock-realtime-example"
 version = "0.0.0"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12"
 
 # put only what this example needs
 dependencies = [

--- a/plugins/aws/pyproject.toml
+++ b/plugins/aws/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "AWS (Bedrock LLM, Transcribe STT, Polly TTS) integration for Vision Agents"
 readme = "README.md"
 keywords = ["aws", "bedrock", "transcribe", "polly", "STT", "TTS", "LLM", "AI", "voice agents", "agents"]
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/cartesia/example/pyproject.toml
+++ b/plugins/cartesia/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cartesia-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
     "vision-agents",

--- a/plugins/cartesia/pyproject.toml
+++ b/plugins/cartesia/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Cartesia TTS integration for Vision Agents"
 readme = "README.md"
 keywords = ["cartesia", "TTS", "text-to-speech", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/decart/example/pyproject.toml
+++ b/plugins/decart/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "decart-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "vision-agents",

--- a/plugins/decart/pyproject.toml
+++ b/plugins/decart/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Decart plugin for Vision Agents"
 readme = "README.md"
 keywords = ["decart", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/deepgram/example/pyproject.toml
+++ b/plugins/deepgram/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deepgram-tts-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/deepgram/pyproject.toml
+++ b/plugins/deepgram/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Deepgram STT and TTS integration for Vision Agents"
 readme = "README.md"
 keywords = ["deepgram", "STT", "TTS", "speech-to-text", "text-to-speech", "transcription", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/elevenlabs/example/pyproject.toml
+++ b/plugins/elevenlabs/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "elevenlabs-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/elevenlabs/example/pyproject.toml
+++ b/plugins/elevenlabs/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "elevenlabs-example"
 version = "0.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/elevenlabs/pyproject.toml
+++ b/plugins/elevenlabs/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "ElevenLabs TTS and STT integration for Vision Agents"
 readme = "README.md"
 keywords = ["elevenlabs", "TTS", "text-to-speech", "STT", "speech-to-text", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/fast_whisper/example/pyproject.toml
+++ b/plugins/fast_whisper/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fast-whisper-example"
 version = "0.1.0"
 description = "Fast Whisper STT example"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-fast-whisper",

--- a/plugins/fast_whisper/example/pyproject.toml
+++ b/plugins/fast_whisper/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fast-whisper-example"
 version = "0.1.0"
 description = "Fast Whisper STT example"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-fast-whisper",

--- a/plugins/fast_whisper/pyproject.toml
+++ b/plugins/fast_whisper/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Fast Whisper STT integration for Vision Agents"
 readme = "README.md"
 keywords = ["faster-whisper", "STT", "speech-to-text", "AI", "voice agents", "agents", "whisper"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/fish/example/pyproject.toml
+++ b/plugins/fish/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fish-tts-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/fish/example/pyproject.toml
+++ b/plugins/fish/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fish-tts-example"
 version = "0.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/fish/pyproject.toml
+++ b/plugins/fish/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Fish Audio TTS and STT integration for Vision Agents"
 readme = "README.md"
 keywords = ["fish-audio", "TTS", "STT", "text-to-speech", "speech-to-text", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/gemini/example/pyproject.toml
+++ b/plugins/gemini/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gemini-vlm-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/gemini/pyproject.toml
+++ b/plugins/gemini/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Google Gemini LLM integration for Vision Agents"
 readme = "README.md"
 keywords = ["gemini", "google", "LLM", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/getstream/pyproject.toml
+++ b/plugins/getstream/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",
-    "getstream[webrtc,telemetry]>=3.3.4,<4",
+    "getstream[webrtc,telemetry]>=3.4.0,<4",
 ]
 
 [project.urls]

--- a/plugins/getstream/pyproject.toml
+++ b/plugins/getstream/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "GetStream video/voice integration for Vision Agents"
 readme = "README.md"
 keywords = ["getstream", "video", "realtime", "streaming", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/huggingface/examples/inference_api/pyproject.toml
+++ b/plugins/huggingface/examples/inference_api/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "huggingface-inference-api-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/huggingface/examples/transformers/pyproject.toml
+++ b/plugins/huggingface/examples/transformers/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "huggingface-transformers-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/huggingface/pyproject.toml
+++ b/plugins/huggingface/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "HuggingFace Inference integration for Vision Agents"
 readme = "README.md"
 keywords = ["huggingface", "LLM", "AI", "voice agents", "agents", "inference"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/inworld/example/pyproject.toml
+++ b/plugins/inworld/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "inworld-tts-example"
 version = "0.1.0"
 description = "Example using Inworld AI TTS with Vision Agents"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "vision-agents-plugins-inworld",
     "vision-agents-plugins-getstream",

--- a/plugins/inworld/example/pyproject.toml
+++ b/plugins/inworld/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "inworld-tts-example"
 version = "0.1.0"
 description = "Example using Inworld AI TTS with Vision Agents"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "vision-agents-plugins-inworld",
     "vision-agents-plugins-getstream",

--- a/plugins/inworld/pyproject.toml
+++ b/plugins/inworld/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Inworld AI integration for Vision Agents (TTS + Realtime WebRTC)"
 readme = "README.md"
 keywords = ["inworld", "TTS", "text-to-speech", "realtime", "webrtc", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/lemonslice/example/pyproject.toml
+++ b/plugins/lemonslice/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lemonslice-avatar-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
     "python-dotenv>=1.0",

--- a/plugins/lemonslice/pyproject.toml
+++ b/plugins/lemonslice/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LemonSlice avatar plugin for Vision Agents"
 readme = "README.md"
 keywords = ["lemonslice", "avatars", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/liveavatar/example/pyproject.toml
+++ b/plugins/liveavatar/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "liveavatar-avatar-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
     "python-dotenv>=1.0",

--- a/plugins/liveavatar/pyproject.toml
+++ b/plugins/liveavatar/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LiveAvatar plugin for Vision Agents"
 readme = "README.md"
 keywords = ["heygen", "liveavatar", "avatars", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/local/pyproject.toml
+++ b/plugins/local/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Local audio & video integration for Vision Agents"
 readme = "README.md"
 keywords = ["local", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/mistral/example/pyproject.toml
+++ b/plugins/mistral/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mistral-stt-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/mistral/example/pyproject.toml
+++ b/plugins/mistral/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mistral-stt-example"
 version = "0.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/mistral/pyproject.toml
+++ b/plugins/mistral/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Mistral Voxtral STT integration for Vision Agents"
 readme = "README.md"
 keywords = ["mistral", "voxtral", "real-time", "STT", "speech-to-text", "transcription", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/moondream/example/pyproject.toml
+++ b/plugins/moondream/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "moondream-example"
 version = "0.1.0"
 description = "Example using Moondream Detect and VLM with Vision Agents"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-moondream",

--- a/plugins/moondream/example/pyproject.toml
+++ b/plugins/moondream/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "moondream-example"
 version = "0.1.0"
 description = "Example using Moondream Detect and VLM with Vision Agents"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-moondream",

--- a/plugins/moondream/pyproject.toml
+++ b/plugins/moondream/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-moondream"
 dynamic = ["version"]
 description = "Moondream 3 vision processor plugin for Vision Agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/nvidia/example/pyproject.toml
+++ b/plugins/nvidia/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nvidia-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/nvidia/pyproject.toml
+++ b/plugins/nvidia/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "NVIDIA VLM plugin for Vision Agents"
 readme = "README.md"
 keywords = ["nvidia", "VLM", "AI", "vision agents", "agents", "nvcf"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/openai/examples/nemotron_example/pyproject.toml
+++ b/plugins/openai/examples/nemotron_example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nemotron-example"
 version = "0.1.0"
 description = "Fraud detection demo using NVIDIA Nemotron on Baseten with Vision Agents"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-openai",

--- a/plugins/openai/examples/qwen_vl_example/pyproject.toml
+++ b/plugins/openai/examples/qwen_vl_example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "qwen3-vl-example"
 version = "0.1.0"
 description = "Example using Qwen3 VL hosted on Baseten with Vision Agents"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-openai",

--- a/plugins/openai/pyproject.toml
+++ b/plugins/openai/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-openai"
 dynamic = ["version"]
 description = "OpenAI plugin for vision agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/openrouter/example/pyproject.toml
+++ b/plugins/openrouter/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openrouter-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/openrouter/example/pyproject.toml
+++ b/plugins/openrouter/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openrouter-example"
 version = "0.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/openrouter/pyproject.toml
+++ b/plugins/openrouter/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-openrouter"
 dynamic = ["version"]
 description = "OpenRouter plugin for vision agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/pocket/example/pyproject.toml
+++ b/plugins/pocket/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pocket-tts-example"
 version = "0.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/pocket/example/pyproject.toml
+++ b/plugins/pocket/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pocket-tts-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/pocket/pyproject.toml
+++ b/plugins/pocket/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Pocket TTS integration for Vision Agents - lightweight CPU-based text-to-speech"
 readme = "README.md"
 keywords = ["pocket-tts", "TTS", "text-to-speech", "AI", "voice agents", "agents", "kyutai"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/qwen/example/pyproject.toml
+++ b/plugins/qwen/example/pyproject.toml
@@ -2,7 +2,7 @@
 name = "qwen-omni-example"
 version = "0.1.0"
 description = "Example using Qwen Omni with Vision Agents"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "vision-agents",
     "vision-agents-plugins-qwen",

--- a/plugins/qwen/pyproject.toml
+++ b/plugins/qwen/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-qwen"
 dynamic = ["version"]
 description = "Qwen Omni plugin for vision agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/roboflow/examples/detection/pyproject.toml
+++ b/plugins/roboflow/examples/detection/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "roboflow-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/roboflow/pyproject.toml
+++ b/plugins/roboflow/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-roboflow"
 dynamic = ["version"]
 description = "Roboflow object detection plugin for Vision Agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/sample_plugin/example/pyproject.toml
+++ b/plugins/sample_plugin/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "my-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 # put only what this example needs
 dependencies = [

--- a/plugins/sample_plugin/pyproject.toml
+++ b/plugins/sample_plugin/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-elevenlabs"
 version = "0.1.0"
 description = "ElevenLabs plugin for GetStream"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/sarvam/example/pyproject.toml
+++ b/plugins/sarvam/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sarvam-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/sarvam/pyproject.toml
+++ b/plugins/sarvam/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
     "voice agents",
     "agents",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/smart_turn/pyproject.toml
+++ b/plugins/smart_turn/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-smart-turn"
 dynamic = ["version"]
 description = "Smart Turn detection plugin for Vision Agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/tencent/pyproject.toml
+++ b/plugins/tencent/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Tencent TRTC edge transport for Vision Agents"
 readme = "README.md"
 keywords = ["tencent", "trtc", "rtc", "edge", "vision agents", "voice agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 classifiers = ["Operating System :: POSIX :: Linux"]
 dependencies = [

--- a/plugins/turbopuffer/pyproject.toml
+++ b/plugins/turbopuffer/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "TurboPuffer RAG integration for Vision Agents with hybrid search"
 readme = "README.md"
 keywords = ["turbopuffer", "RAG", "vector-search", "hybrid-search", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/twilio/pyproject.toml
+++ b/plugins/twilio/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-twilio"
 dynamic = ["version"]
 description = "Twilio plugin for Vision Agents - Voice call integration with media streaming"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/ultralytics/pyproject.toml
+++ b/plugins/ultralytics/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-ultralytics"
 dynamic = ["version"]
 description = "Ultralytics YOLO plugin for GetStream"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/vogent/pyproject.toml
+++ b/plugins/vogent/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-vogent"
 dynamic = ["version"]
 description = "Vogent turn keeping plugin for Vision Agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/vogent/pyproject.toml
+++ b/plugins/vogent/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-vogent"
 dynamic = ["version"]
 description = "Vogent turn keeping plugin for Vision Agents"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/wizper/example/pyproject.toml
+++ b/plugins/wizper/example/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wizper-example"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dotenv>=1.0",

--- a/plugins/wizper/pyproject.toml
+++ b/plugins/wizper/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Wizper plugin for Vision Agents"
 readme = "README.md"
 keywords = ["fal", "turn detection", "AI", "voice agents", "agents"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "vision-agents",

--- a/plugins/xai/pyproject.toml
+++ b/plugins/xai/pyproject.toml
@@ -7,7 +7,7 @@ name = "vision-agents-plugins-xai"
 dynamic = ["version"]
 description = "XAI for stream agents"
 readme = "README.md"
-requires-python = ">=3.10.0,<3.14"
+requires-python = ">=3.10.0"
 license = "Apache-2.0"
 dependencies = [
     "vision-agents",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,6 @@ requires = ["hatchling", "hatch-vcs", "setuptools-scm"]
 build-backend = "hatchling.build"
 
 [tool.uv.sources]
-# Temporary: pin getstream to a main commit that adds Python 3.14 support.
-# Drop once a release containing https://github.com/GetStream/stream-py/pull/253 is on PyPI.
-getstream = { git = "https://github.com/GetStream/stream-py.git", rev = "c112150845c3233d8a5fc76dc1a9333cddd10364" }
 vision-agents = { workspace = true }
 vision-agents-plugins-anthropic = { workspace = true }
 vision-agents-plugins-aws = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ requires = ["hatchling", "hatch-vcs", "setuptools-scm"]
 build-backend = "hatchling.build"
 
 [tool.uv.sources]
+# Temporary: pin getstream to a main commit that adds Python 3.14 support.
+# Drop once a release containing https://github.com/GetStream/stream-py/pull/253 is on PyPI.
+getstream = { git = "https://github.com/GetStream/stream-py.git", rev = "c112150845c3233d8a5fc76dc1a9333cddd10364" }
 vision-agents = { workspace = true }
 vision-agents-plugins-anthropic = { workspace = true }
 vision-agents-plugins-aws = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -1138,34 +1138,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1714,7 +1714,7 @@ wheels = [
 [[package]]
 name = "getstream"
 version = "3.3.4"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/GetStream/stream-py.git?rev=c112150845c3233d8a5fc76dc1a9333cddd10364#c112150845c3233d8a5fc76dc1a9333cddd10364" }
 dependencies = [
     { name = "dataclasses-json" },
     { name = "httpx" },
@@ -1727,10 +1727,6 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-dateutil" },
     { name = "twirp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/d0/5398f3e712004aba1d629ef7362a6c941967ef052e066fe5f0354014bd12/getstream-3.3.4.tar.gz", hash = "sha256:091226d96e8e7f51b8feaaaa09d33eae37df8e799039a3c96032e54594501e98", size = 528252, upload-time = "2026-05-15T12:03:03.61Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/e6/4c5452cee3aa9af1fa873b93bdc944611af27abbfa4b92cab0e31e680e94/getstream-3.3.4-py3-none-any.whl", hash = "sha256:9ba009256fb1a99015acb5cf681ca7df52604f3a0214bea4c1831155156e45d1", size = 336140, upload-time = "2026-05-15T12:03:01.961Z" },
 ]
 
 [package.optional-dependencies]
@@ -3243,7 +3239,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3282,7 +3278,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3294,7 +3290,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3324,9 +3320,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3338,7 +3334,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -6458,7 +6454,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "fastapi", specifier = ">=0.135.1" },
-    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.4,<4" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], git = "https://github.com/GetStream/stream-py.git?rev=c112150845c3233d8a5fc76dc1a9333cddd10364" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "mcp", specifier = ">=1.23.3,<2" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -6857,7 +6853,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.3.4,<4" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], git = "https://github.com/GetStream/stream-py.git?rev=c112150845c3233d8a5fc76dc1a9333cddd10364" },
     { name = "vision-agents", editable = "agents-core" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1713,8 +1713,8 @@ wheels = [
 
 [[package]]
 name = "getstream"
-version = "3.3.4"
-source = { git = "https://github.com/GetStream/stream-py.git?rev=c112150845c3233d8a5fc76dc1a9333cddd10364#c112150845c3233d8a5fc76dc1a9333cddd10364" }
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dataclasses-json" },
     { name = "httpx" },
@@ -1727,6 +1727,10 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-dateutil" },
     { name = "twirp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/c9/46a87f7571645fb64b1ae7fac198d8dfc7d352e52cb580602ab7b596b925/getstream-3.4.0.tar.gz", hash = "sha256:a2ef23807f7960de6d68b0c211769cb4095e40fc2e002fbfdcde2bbc5693bb92", size = 562754, upload-time = "2026-05-25T20:58:42.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/25/12489ca22c10e7d1ec37bfb7be3b983dcd7b2ac187c0433b618c8c3ac981/getstream-3.4.0-py3-none-any.whl", hash = "sha256:5fb610c5d61941e6a503e4bcbddc8d815aa99892da9d322774dd2e96592008d5", size = 352147, upload-time = "2026-05-25T20:58:44.115Z" },
 ]
 
 [package.optional-dependencies]
@@ -6454,7 +6458,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "fastapi", specifier = ">=0.135.1" },
-    { name = "getstream", extras = ["telemetry", "webrtc"], git = "https://github.com/GetStream/stream-py.git?rev=c112150845c3233d8a5fc76dc1a9333cddd10364" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.4.0,<4" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "mcp", specifier = ">=1.23.3,<2" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -6853,7 +6857,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "getstream", extras = ["telemetry", "webrtc"], git = "https://github.com/GetStream/stream-py.git?rev=c112150845c3233d8a5fc76dc1a9333cddd10364" },
+    { name = "getstream", extras = ["telemetry", "webrtc"], specifier = ">=3.4.0,<4" },
     { name = "vision-agents", editable = "agents-core" },
 ]
 


### PR DESCRIPTION
## Why

#573 capped every workspace member at `<3.14` because the transitive `scipy<1.16` from `getstream[webrtc]` had no `cp314` wheels. https://github.com/GetStream/stream-py/pull/253 fixes that on the `getstream` side (bumps `numpy>=2.3.2` / `scipy>=1.16.1` under `python_version >= '3.14'`), so the cap can come off.

There is no `getstream` release with the fix yet, so the workspace temporarily sources `getstream` from a `main` commit via `[tool.uv.sources]`. Drop the pin when a release lands on PyPI.

The change also surfaces — and fixes — a latent issue: `smart_turn` and `vogent` both depend on `onnxruntime>=1.24.3`, which has no `cp310` wheels, but their `requires-python` advertised `>=3.10`. Anyone installing them on 3.10 hit an unsatisfiable resolution. Their `requires-python` is now `>=3.11`.

To stop this kind of metadata-vs-reality drift in the future, this PR adds `dev.py check-python-versions <ver>` and a 3.10–3.14 matrix workflow that runs it. The check resolves each workspace member's `pyproject.toml` from a tmpdir (so the workspace's `override-dependencies` don't mask the install path that real PyPI consumers take) and skips members whose `requires-python` excludes the target. That's the check that caught `smart_turn`/`vogent` above.

Local matrix run after the fix:

```
3.10: 33 OK, skip aws/smart_turn/vogent
3.11: 35 OK, skip aws
3.12: 36 OK
3.13: 36 OK
3.14: 34 OK, skip kokoro/smart_turn
```

`kokoro` and `smart_turn` stay capped at `<3.14`: both pin `numpy<2.3`, which conflicts with the `numpy>=2.3.2` `getstream[webrtc]` carries on 3.14.