### PR TITLE
test: silence MagicMock await warning on agent edge close

### DIFF
--- a/tests/test_agents/test_agent_launcher.py
+++ b/tests/test_agents/test_agent_launcher.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
 import redis.asyncio as redis
@@ -53,6 +53,7 @@ class DummyLLM(LLM, Warmable[bool]):
 async def stream_edge_mock() -> MagicMock:
     mock = MagicMock()
     mock.events = EventManager()
+    mock.close = AsyncMock()
     return mock
 
 

--- a/tests/test_agents/test_runner.py
+++ b/tests/test_agents/test_runner.py
@@ -1,7 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from asgi_lifespan import LifespanManager
@@ -43,6 +43,7 @@ def agent_launcher_factory():
         async def create_agent(**kwargs) -> Agent:
             stream_edge_mock = MagicMock()
             stream_edge_mock.events = EventManager()
+            stream_edge_mock.close = AsyncMock()
 
             return Agent(
                 llm=DummyLLM(),


### PR DESCRIPTION
## Why

After #578 the agent's `_stop_components` awaits `edge.close()`, which logged a TypeError for the synchronous MagicMock edge used in launcher and runner tests. Configure only `close` as AsyncMock so sync edge methods (e.g. `create_audio_track`) keep returning mocks.