### PR TITLE
chore(plugins): scope wheel packages to vision_agents only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,11 @@ module-level `logger = logging.getLogger(__name__)`. Use `debug` for lifecycle, 
 - Change only what I asked for. Don't refactor adjacent code — ask first.
 - Do not remove valid comments when editing/refactoring code.
 
+## Plugins
+
+- In every `plugins/*/pyproject.toml`, the wheel target must be `packages = ["vision_agents"]`. Listing `"."` pulls `tests/`, `README.md`, `example/`, etc. into the published wheel.
+- Each plugin must keep `readme = "README.md"` in `[project]` and a `README.md` next to its `pyproject.toml` so PyPI renders a description page.
+
 ## Token efficiency
 
 - When making multiple related changes to the same file, combine them into fewer Edit calls with enough surrounding context, rather than one edit per change.

--- a/plugins/anam/pyproject.toml
+++ b/plugins/anam/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/anthropic/pyproject.toml
+++ b/plugins/anthropic/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/assemblyai/pyproject.toml
+++ b/plugins/assemblyai/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/aws/pyproject.toml
+++ b/plugins/aws/pyproject.toml
@@ -28,7 +28,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/cartesia/pyproject.toml
+++ b/plugins/cartesia/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/decart/pyproject.toml
+++ b/plugins/decart/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/deepgram/pyproject.toml
+++ b/plugins/deepgram/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/elevenlabs/pyproject.toml
+++ b/plugins/elevenlabs/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/fast_whisper/pyproject.toml
+++ b/plugins/fast_whisper/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/fish/pyproject.toml
+++ b/plugins/fish/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/getstream/pyproject.toml
+++ b/plugins/getstream/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/huggingface/pyproject.toml
+++ b/plugins/huggingface/pyproject.toml
@@ -38,7 +38,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/inworld/pyproject.toml
+++ b/plugins/inworld/pyproject.toml
@@ -28,7 +28,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/kokoro/pyproject.toml
+++ b/plugins/kokoro/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/lemonslice/pyproject.toml
+++ b/plugins/lemonslice/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/liveavatar/pyproject.toml
+++ b/plugins/liveavatar/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/local/pyproject.toml
+++ b/plugins/local/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/mistral/pyproject.toml
+++ b/plugins/mistral/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/moondream/pyproject.toml
+++ b/plugins/moondream/pyproject.toml
@@ -30,7 +30,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.uv.sources]
 vision-agents = { workspace = true }

--- a/plugins/nvidia/pyproject.toml
+++ b/plugins/nvidia/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/openai/pyproject.toml
+++ b/plugins/openai/pyproject.toml
@@ -24,7 +24,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.uv.sources]
 vision-agents = { workspace = true }

--- a/plugins/openrouter/pyproject.toml
+++ b/plugins/openrouter/pyproject.toml
@@ -24,7 +24,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.uv.sources]
 vision-agents = { workspace = true }

--- a/plugins/pocket/pyproject.toml
+++ b/plugins/pocket/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/qdrant/pyproject.toml
+++ b/plugins/qdrant/pyproject.toml
@@ -26,7 +26,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/qwen/pyproject.toml
+++ b/plugins/qwen/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.uv.sources]
 vision-agents = { workspace = true }

--- a/plugins/roboflow/pyproject.toml
+++ b/plugins/roboflow/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.uv.sources]
 vision-agents = { workspace = true }

--- a/plugins/sample_plugin/pyproject.toml
+++ b/plugins/sample_plugin/pyproject.toml
@@ -24,7 +24,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/sarvam/pyproject.toml
+++ b/plugins/sarvam/pyproject.toml
@@ -37,7 +37,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/smart_turn/pyproject.toml
+++ b/plugins/smart_turn/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/tencent/pyproject.toml
+++ b/plugins/tencent/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/turbopuffer/pyproject.toml
+++ b/plugins/turbopuffer/pyproject.toml
@@ -27,7 +27,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/twilio/pyproject.toml
+++ b/plugins/twilio/pyproject.toml
@@ -26,7 +26,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/ultralytics/pyproject.toml
+++ b/plugins/ultralytics/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.uv.sources]
 vision-agents = { workspace = true }

--- a/plugins/vogent/pyproject.toml
+++ b/plugins/vogent/pyproject.toml
@@ -29,7 +29,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = [".", "vision_agents"]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]

--- a/plugins/wizper/pyproject.toml
+++ b/plugins/wizper/pyproject.toml
@@ -25,7 +25,7 @@ source = "vcs"
 raw-options = { root = "..", search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
+packages = ["vision_agents"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/vision_agents"]


### PR DESCRIPTION
## Why

Every plugin's `[tool.hatch.build.targets.wheel]` lists `packages = ["."]` or `[".", "vision_agents"]`. With `.` in the list, hatchling walks the plugin's top-level directory and pulls everything it finds — `tests/`, `README.md`, `example/`, even `pyproject.toml` itself — into the published wheel. That bloats artifacts and ships test code to users.

Scoping to `packages = ["vision_agents"]` (the convention already used by `gemini` and `xai`) keeps wheels to the import package only. Verified by building `vision-agents-plugins-qdrant` and `vision-agents-plugins-getstream` locally: both wheels now contain only `vision_agents/plugins/<name>/` plus the standard dist-info.