### PR TITLE
fix(gemini): exit tool loop when all follow-up calls are duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-### `gemini` plugin: crash on duplicate follow-up tool calls
+### `gemini` plugin: crash on duplicate follow-up tool calls (#588)
 
 `GeminiLLM.simple_response` crashed with `ValueError('content parts are required.')` when the model echoed an already-executed function call in a follow-up turn. `_dedup_and_execute` filtered it out, leaving the follow-up `chat.send_message_stream(parts=[], ...)` with an empty list, which google-genai rejects. The multi-hop loop now exits cleanly when every requested call is a duplicate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Bug Fixes
+
+### `gemini` plugin: crash on duplicate follow-up tool calls
+
+`GeminiLLM.simple_response` crashed with `ValueError('content parts are required.')` when the model echoed an already-executed function call in a follow-up turn. `_dedup_and_execute` filtered it out, leaving the follow-up `chat.send_message_stream(parts=[], ...)` with an empty list, which google-genai rejects. The multi-hop loop now exits cleanly when every requested call is a duplicate.
+
 # v0.6.2
 
 ## Breaking Changes

--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -1,5 +1,4 @@
 import os
-from typing import Any
 
 import pytest
 from dotenv import load_dotenv
@@ -119,7 +118,7 @@ class TestGeminiLLM:
             def __init__(self) -> None:
                 self.received: list[tuple[tuple, dict]] = []
 
-            async def send_message_stream(self, *args: Any, **kwargs: Any):
+            async def send_message_stream(self, *args: object, **kwargs: object):
                 message = args[0] if args else kwargs.get("message")
                 # mirror google-genai's t_parts() guard
                 if isinstance(message, list) and not message:

--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -131,7 +131,8 @@ class TestGeminiLLM:
 
                 return _iter()
 
-        llm.chat = _FakeChat()
+        fake = _FakeChat()
+        llm.chat = fake
 
         try:
             async for _ in llm.simple_response("call probe"):
@@ -140,6 +141,12 @@ class TestGeminiLLM:
             if "content parts are required" in str(exc):
                 pytest.fail(f"empty-parts bug regressed: {exc}")
             raise
+
+        # Initial text turn + exactly one follow-up with the tool result.
+        # A third call would mean we sent parts=[] (the bug).
+        assert len(fake.received) == 2
+        follow_up_args, _ = fake.received[1]
+        assert follow_up_args and follow_up_args[0], "follow-up parts must be non-empty"
 
 
 @pytest.mark.integration

--- a/plugins/gemini/tests/test_gemini_llm.py
+++ b/plugins/gemini/tests/test_gemini_llm.py
@@ -1,7 +1,9 @@
 import os
+from typing import Any
 
 import pytest
 from dotenv import load_dotenv
+from google.genai import types
 from vision_agents.core.agents.conversation import InMemoryConversation, Message
 from vision_agents.plugins.gemini.gemini_llm import (
     GeminiLLM,
@@ -85,6 +87,59 @@ class TestGeminiLLM:
         ]
         assert "$schema" not in schema
         assert "$schema" not in schema["properties"]["inner"]
+
+    async def test_duplicate_tool_calls_in_followup_do_not_send_empty_parts(
+        self, llm: GeminiLLM
+    ):
+        """If the model echoes the same function call after a tool result,
+        `_dedup_and_execute` filters it out and the loop ends up calling
+        `chat.send_message_stream(parts=[], ...)`, which google-genai rejects
+        with `ValueError('content parts are required.')`.
+        """
+        # The bug is model-agnostic. We pick a non-"gemini-3" name only to skip
+        # the gemini-3 history-cleanup branch, which would require the fake chat
+        # to implement get_history() and client.chats.create().
+        llm.model = "gemini-2.5-pro"
+
+        @llm.register_function(description="probe")
+        async def probe(ping: str) -> str:
+            return f"ok:{ping}"
+
+        def _function_call_chunk() -> types.GenerateContentResponse:
+            part = types.Part(
+                function_call=types.FunctionCall(name="probe", args={"ping": "pong"})
+            )
+            return types.GenerateContentResponse(
+                candidates=[
+                    types.Candidate(content=types.Content(role="model", parts=[part]))
+                ]
+            )
+
+        class _FakeChat:
+            def __init__(self) -> None:
+                self.received: list[tuple[tuple, dict]] = []
+
+            async def send_message_stream(self, *args: Any, **kwargs: Any):
+                message = args[0] if args else kwargs.get("message")
+                # mirror google-genai's t_parts() guard
+                if isinstance(message, list) and not message:
+                    raise ValueError("content parts are required.")
+                self.received.append((args, kwargs))
+
+                async def _iter():
+                    yield _function_call_chunk()
+
+                return _iter()
+
+        llm.chat = _FakeChat()
+
+        try:
+            async for _ in llm.simple_response("call probe"):
+                pass
+        except ValueError as exc:
+            if "content parts are required" in str(exc):
+                pytest.fail(f"empty-parts bug regressed: {exc}")
+            raise
 
 
 @pytest.mark.integration

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_llm.py
@@ -293,6 +293,17 @@ class GeminiLLM(LLM):
 
                     parts.append(func_response_part)
 
+                # If every requested call was a duplicate already executed in a
+                # previous round, `parts` is empty. Sending it would trip
+                # google-genai's `t_parts` guard with "content parts are required.".
+                if not parts:
+                    logger.warning(
+                        "Gemini returned only duplicate tool calls in round %d; "
+                        "ending tool loop to avoid empty follow-up message.",
+                        rounds,
+                    )
+                    break
+
                 # Fix for Gemini 3 Pro: Remove empty model messages from history
                 # Gemini 3 Pro streaming adds an empty model message after function calls
                 # which breaks the "function response must immediately follow function call" requirement


### PR DESCRIPTION
## Why

`GeminiLLM.simple_response` could crash mid-stream with `ValueError('content parts are required.')` whenever Gemini echoed an already-executed function call in a follow-up turn. The multi-hop tool loop in `gemini_llm.py` calls `_dedup_and_execute`, which correctly filters out duplicate `(id, name, args)` keys it has already run this turn; when *every* requested call is a duplicate, it returns an empty `triples`. The loop then walked an empty `for tc, res, err in triples:` (zero iterations), kept `parts = []`, and unconditionally forwarded that to `chat.send_message_stream(parts, config=...)`. google-genai's `t_parts` guard rejects empty lists with the observed `ValueError`, surfacing as an unretrieved task exception.

The root cause is that the loop assumed dedup would always leave at least one part to send. It doesn't — duplicate follow-up calls are a real Gemini behavior, especially on Gemini 3 Pro reasoning paths. The fix exits the loop with `break` as soon as `parts` is empty, falling back to the text already streamed in the prior round.

Added a deterministic regression test that drives a fake chat object which always echoes the same `function_call` chunk, reproducing the dedup-to-empty path without depending on the live API.