### PR TITLE
perf(getstream): decouple StreamConversation backend sync from the LLM hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+## New Features
+
+### `getstream` plugin: non-blocking StreamConversation persistence (#589)
+
+`StreamConversation` now persists messages to Stream Chat in the background instead of awaiting each REST round-trip inline. Voice pipelines call `upsert_message` on the critical path (per transcript and per LLM delta), where the inline ~150–300 ms round-trip compounded into audible response latency. Writes are dispatched as fire-and-forget tasks serialized behind a per-channel lock, so ordering is preserved and the final persisted message always matches the final content. Adds `Conversation.wait_for_pending_syncs()`, drained on agent shutdown so in-flight writes are not dropped.
+
 ## Bug Fixes
 
 ### `gemini` plugin: crash on duplicate follow-up tool calls (#588)

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -777,6 +777,11 @@ class Agent:
         self._audio_input_stream.close()
         self._audio_output_stream.close()
 
+        # Drain any background conversation persistence so we don't drop
+        # in-flight Stream Chat writes (e.g. the final assistant message).
+        if self.conversation is not None:
+            await self.conversation.wait_for_pending_syncs()
+
         # Stop metrics broadcast task
         if self._metrics_broadcast_task:
             await cancel_and_wait(self._metrics_broadcast_task)

--- a/agents-core/vision_agents/core/agents/conversation.py
+++ b/agents-core/vision_agents/core/agents/conversation.py
@@ -221,6 +221,14 @@ class Conversation(ABC):
         """
         pass
 
+    async def wait_for_pending_syncs(self) -> None:
+        """Wait for any backend-sync work dispatched in the background.
+
+        Default no-op. Implementations that fire backend syncs as tasks
+        (e.g. ``StreamConversation``) override this to drain those tasks
+        before tests assert or before the agent shuts down.
+        """
+
     def _find_message(self, message_id: str) -> Optional[Message]:
         """Find a message by ID."""
         return next((m for m in self.messages if m.id == message_id), None)

--- a/plugins/getstream/tests/test_message_chunking.py
+++ b/plugins/getstream/tests/test_message_chunking.py
@@ -278,6 +278,7 @@ class TestChunkingIntegration:
         assert conversation.messages[0].content == large_text
 
         # Should have created 3 chunks in Stream
+        await conversation.wait_for_pending_syncs()
         assert len(mock_channel.sent_messages) == 3
 
         # Verify chunk metadata
@@ -308,6 +309,7 @@ class TestChunkingIntegration:
             completed=False,
         )
 
+        await conversation.wait_for_pending_syncs()
         assert len(mock_channel.sent_messages) == 1
         assert conversation.messages[0].content == "Short"
         # First chunk created with generating=True (it's the last/only chunk initially)
@@ -324,6 +326,7 @@ class TestChunkingIntegration:
         )
 
         # Should have created a new chunk (2 total)
+        await conversation.wait_for_pending_syncs()
         assert len(mock_channel.sent_messages) == 2
 
         # Chunk 1 (last, newly created): should have generating=True
@@ -358,6 +361,7 @@ class TestChunkingIntegration:
             completed=False,
         )
 
+        await conversation.wait_for_pending_syncs()
         initial_chunk_count = len(mock_channel.sent_messages)
         assert initial_chunk_count >= 2
 
@@ -373,6 +377,7 @@ class TestChunkingIntegration:
         )
 
         # Should have deleted extra chunks
+        await conversation.wait_for_pending_syncs()
         assert mock_channel.client.delete_message.call_count == initial_chunk_count - 1
 
     @pytest.mark.asyncio
@@ -394,6 +399,7 @@ End."""
         )
 
         # Verify code block is complete in at least one chunk
+        await conversation.wait_for_pending_syncs()
         full_text = "".join(req.text for req in mock_channel.sent_messages)
         assert "```python" in full_text
         assert "def hello():" in full_text
@@ -411,6 +417,7 @@ End."""
             content=large_text,
         )
 
+        await conversation.wait_for_pending_syncs()
         chunks_created = len(mock_channel.sent_messages)
 
         # Verify metadata on all chunks
@@ -444,6 +451,7 @@ End."""
         )
 
         # Check the requests sent
+        await conversation.wait_for_pending_syncs()
         chunks_sent = len(mock_channel.sent_messages)
         assert chunks_sent >= 2
 

--- a/plugins/getstream/tests/test_stream_conversation.py
+++ b/plugins/getstream/tests/test_stream_conversation.py
@@ -73,7 +73,8 @@ class TestStreamConversation:
         assert stream_conversation.messages[0].role == "user"
         assert stream_conversation.messages[0].user_id == "user123"
 
-        # Verify Stream API was called
+        # Verify Stream API was called (backend sync runs as a task)
+        await stream_conversation.wait_for_pending_syncs()
         mock_channel.send_message.assert_called_once()
         call_args = mock_channel.send_message.call_args
         request = call_args[0][0]
@@ -98,7 +99,8 @@ class TestStreamConversation:
         assert stream_conversation.messages[0].role == "user"
         assert stream_conversation.messages[0].user_id == "user123"
 
-        # Verify Stream API was called
+        # Verify Stream API was called (backend sync runs as a task)
+        await stream_conversation.wait_for_pending_syncs()
         mock_channel.send_message.assert_called_once()
         call_args = mock_channel.send_message.call_args
         request = call_args[0][0]
@@ -123,6 +125,7 @@ class TestStreamConversation:
 
         assert len(stream_conversation.messages) == 1
         assert stream_conversation.messages[0].content == "Hello"
+        await stream_conversation.wait_for_pending_syncs()
         mock_channel.send_message.assert_called_once()
 
         # Delta 2
@@ -139,6 +142,7 @@ class TestStreamConversation:
         assert len(stream_conversation.messages) == 1
         assert stream_conversation.messages[0].content == "Hello world"
         # Should call ephemeral update, not send_message
+        await stream_conversation.wait_for_pending_syncs()
         mock_channel.send_message.assert_not_called()
         mock_channel.client.ephemeral_message_update.assert_called_once()
 
@@ -181,6 +185,7 @@ class TestStreamConversation:
         assert stream_conversation.messages[0].content == "Hello world!"
 
         # Should call update_message_partial for completion
+        await stream_conversation.wait_for_pending_syncs()
         mock_channel.client.update_message_partial.assert_called_once()
 
     @pytest.mark.asyncio
@@ -317,6 +322,7 @@ async def test_streaming_deltas_then_completion_integration():
     assert conversation.messages[0].content == "Hello world!"
 
     # Verify only 1 message in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -375,6 +381,7 @@ async def test_completion_before_deltas_integration():
     assert conversation.messages[0].content == full_text
 
     # Verify only 1 message in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -442,6 +449,7 @@ async def test_out_of_order_fragments_integration():
     assert len(conversation.messages) == 1
 
     # Verify in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -499,6 +507,7 @@ async def test_race_condition_delta_and_completion_concurrent():
     assert conversation.messages[0].content == "The old lighthouse keeper..."
 
     # Verify only 1 message in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -551,6 +560,7 @@ async def test_concurrent_messages():
     assert len(conversation.messages) == 2
 
     # Verify in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -592,6 +602,7 @@ async def test_large_message_chunking_integration():
     assert conversation.messages[0].content == large_text
 
     # Should have 3 chunks in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -686,6 +697,7 @@ async def test_streaming_with_chunking_integration():
     assert conversation.messages[0].content == final_text
 
     # Should have 2 chunks in Stream (3rd deleted)
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )
@@ -749,6 +761,7 @@ And here's more text after the code block to force multiple chunks."""
     assert len(conversation.messages) == 1
 
     # Should have multiple chunks in Stream
+    await conversation.wait_for_pending_syncs()
     response = await channel.get_or_create(
         state=True, messages=MessagePaginationParams(limit=10)
     )

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_conversation.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_conversation.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from typing import List, Dict
+from typing import List, Dict, Set
 
 from getstream.models import MessageRequest
 from getstream.chat.async_channel import Channel
@@ -15,7 +16,18 @@ logger = logging.getLogger(__name__)
 
 
 class StreamConversation(Conversation):
-    """Persists the message history to a Stream channel with automatic chunking."""
+    """Persists the message history to a Stream channel with automatic chunking.
+
+    Backend persistence is dispatched as fire-and-forget tasks so that callers
+    of ``upsert_message`` are not blocked on Stream Chat round-trips. Voice
+    pipelines call ``upsert_message`` on the critical path (per user
+    transcript and per LLM delta); awaiting the REST sync inline added ~150–
+    300 ms per call, which compounded into perceptible audio latency.
+
+    Ordering is preserved by serializing dispatched tasks behind a per-channel
+    asyncio.Lock. Tests and shutdown paths can call
+    ``wait_for_pending_syncs()`` to drain in-flight tasks.
+    """
 
     # Maps internal message IDs to first Stream message ID (for backward compatibility)
     internal_ids_to_stream_ids: Dict[str, str]
@@ -41,17 +53,36 @@ class StreamConversation(Conversation):
         self.channel = channel
         self.internal_ids_to_stream_ids = {}
         self.chunk_size = chunk_size
+        self._sync_lock = asyncio.Lock()
+        self._pending_syncs: Set[asyncio.Task] = set()
 
     async def _sync_to_backend(
         self, message: Message, state: MessageState, completed: bool
     ):
-        """Sync message to Stream Chat API with automatic chunking.
+        """Dispatch the Stream Chat sync as a serialized background task.
 
-        Args:
-            message: The message to sync
-            state: The message's internal state
-            completed: If True, finalize the message. If False, mark as still generating.
+        Returns immediately so the caller (e.g. an LLM-delta hot path) is not
+        blocked on the REST round-trip. Tasks queue on ``_sync_lock`` to
+        preserve write ordering against the same channel.
         """
+        task = asyncio.create_task(self._sync_with_lock(message, state, completed))
+        self._pending_syncs.add(task)
+        task.add_done_callback(self._pending_syncs.discard)
+
+    async def _sync_with_lock(
+        self, message: Message, state: MessageState, completed: bool
+    ):
+        async with self._sync_lock:
+            try:
+                await self._do_sync(message, state, completed)
+            except Exception:
+                # Fire-and-forget: never let a backend failure escape as an
+                # unretrieved task exception. Catch everything (not just
+                # StreamAPIException) so chunking/encoding/transport errors
+                # are logged instead of silently lost on the hot path.
+                logger.exception("Stream Chat sync failed for message %s", message.id)
+
+    async def _do_sync(self, message: Message, state: MessageState, completed: bool):
         # Split message into chunks (markdown-aware)
         chunks = self._smart_chunk(message.content, self.chunk_size)
 
@@ -62,6 +93,17 @@ class StreamConversation(Conversation):
         else:
             # UPDATE: Update/create/delete chunks as needed
             await self._update_chunks(message, state, chunks, completed)
+
+    async def wait_for_pending_syncs(self) -> None:
+        """Wait for all dispatched backend-sync tasks to complete.
+
+        Useful in tests that assert against the mocked Stream Chat client
+        right after ``upsert_message``, and on graceful shutdown to avoid
+        dropping in-flight persistence work.
+        """
+        if not self._pending_syncs:
+            return
+        await asyncio.gather(*self._pending_syncs, return_exceptions=True)
 
     async def _create_chunks(
         self, message: Message, state: MessageState, chunks: List[str], completed: bool


### PR DESCRIPTION
## Why

`StreamConversation` persisted every message to Stream Chat by awaiting the REST round-trip inline inside `upsert_message`. Voice pipelines call `upsert_message` on the critical path — once per user transcript and once per LLM delta — so each call blocked the audio loop on a ~150–300 ms Stream Chat round-trip, which compounded into perceptible latency in the agent's spoken responses.

This moves persistence off the hot path: `_sync_to_backend` now dispatches the chunked write as a fire-and-forget task serialized behind a per-instance `asyncio.Lock`, so callers return immediately while write ordering to the channel is preserved. The final persisted message always converges to the final in-memory content because the completion write runs last; under rapid deltas intermediate states may be coalesced, which is acceptable since the channel is a transcript record and the live experience is the audio.

`Conversation.wait_for_pending_syncs()` (a no-op on the base, overridden by `StreamConversation`) lets `Agent._close` drain in-flight writes on shutdown so the final assistant message is never dropped, and lets tests assert against the backend deterministically.

The background sync logs all exceptions rather than only `StreamAPIException`, so a chunking or transport failure surfaces in logs instead of being silently lost as an unretrieved task exception on the hot path.

Split out of the Inworld router work to keep that PR focused and reviewable on its own.

## Changes

- `StreamConversation._sync_to_backend` dispatches a serialized background task instead of awaiting inline; `wait_for_pending_syncs()` drains in-flight tasks.
- Adds `Conversation.wait_for_pending_syncs()` base no-op; `Agent._close` drains pending syncs before teardown.
- Background sync catches and logs all exceptions, not only `StreamAPIException`.
