### PR TITLE
Realtime input pacing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## New Features
 
+### Realtime input audio pacing (#599)
+
+Realtime LLMs that need a steady upstream audio cadence can now opt into framework-level pacing. Pass `input_audio_pacing=AudioInputPacingConfig(...)` to a `Realtime` subclass and the framework buffers the irregular PCM the WebRTC uplink delivers and forwards fixed-size chunks (default 20 ms) at a stable wall-clock rate. `AudioInputPacingConfig.virtual_microphone()` is a preset for speech-to-speech models that interpret gaps in the input as end-of-turn — it primes a 500 ms buffer and fills digital silence on a dry buffer so the model never sees an interruption.
+
+### `gemini` plugin: Live Translate model with auto-enabled input pacing (#599)
+
+Adds `gemini-3.5-live-translate-preview` as a supported Live Translate model and bumps the default Gemini Realtime model to `gemini-3.1-flash-live-preview` (was `gemini-2.5-flash-native-audio-preview-12-2025`). The Live Translate model is sensitive to uneven input audio — irregular upstream chunks produce audible jitter and word-cutoffs in its output. `GeminiRealtime` automatically installs `AudioInputPacingConfig.virtual_microphone()` whenever the model is `gemini-3.5-live-translate-preview`, so the framework feeds it a steady 20 ms stream by default. Opt out with `input_audio_pacing=None`.
+
 ### `getstream` plugin: non-blocking StreamConversation persistence (#589)
 
 `StreamConversation` now persists messages to Stream Chat in the background instead of awaiting each REST round-trip inline. Voice pipelines call `upsert_message` on the critical path (per transcript and per LLM delta), where the inline ~150–300 ms round-trip compounded into audible response latency. Writes are dispatched as fire-and-forget tasks serialized behind a per-channel lock, so ordering is preserved and the final persisted message always matches the final content. Adds `Conversation.wait_for_pending_syncs()`, drained on agent shutdown so in-flight writes are not dropped.

--- a/agents-core/vision_agents/core/llm/__init__.py
+++ b/agents-core/vision_agents/core/llm/__init__.py
@@ -1,5 +1,5 @@
 from .llm import LLM, AudioLLM, VideoLLM, OmniLLM
-from .realtime import Realtime
+from .realtime import Realtime, AudioInputPacingConfig
 from .function_registry import FunctionRegistry, function_registry
 
 __all__ = [
@@ -8,6 +8,7 @@ __all__ = [
     "VideoLLM",
     "OmniLLM",
     "Realtime",
+    "AudioInputPacingConfig",
     "FunctionRegistry",
     "function_registry",
 ]

--- a/agents-core/vision_agents/core/llm/llm.py
+++ b/agents-core/vision_agents/core/llm/llm.py
@@ -468,6 +468,8 @@ class AudioLLM(LLM, metaclass=abc.ABCMeta):
     These models do not require TTS and STT services to run.
     """
 
+    connected: bool = False
+
     @abc.abstractmethod
     async def simple_audio_response(self, pcm: PcmData, participant: Participant):
         """

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -19,6 +19,8 @@ from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacer,
     AudioInputPacingConfig,
 )
+from vision_agents.core.utils.audio_input_processor import AudioInputProcessor
+from vision_agents.core.utils.audio_input_direct import AudioInputDirect
 from vision_agents.core.utils.stream import Stream
 
 logger = logging.getLogger(__name__)
@@ -101,21 +103,20 @@ class Realtime(OmniLLM):
         input_audio_pacing: AudioInputPacingConfig | None = None,
     ):
         super().__init__()
-        self.connected = False
-
         self.session_id = str(uuid.uuid4())
         self.fps = fps
-        self._input_audio_pacer: AudioInputPacer | None = (
+        # Store current participant for user speech transcription events
+        self._current_participant: Participant | None = None
+
+        self._audio_input_processor: AudioInputProcessor = (
             AudioInputPacer(
+                self,
                 input_audio_pacing,
-                self._send_paced_audio,
                 name=f"{self.provider_name}_input_pacer",
             )
             if input_audio_pacing is not None
-            else None
+            else AudioInputDirect(self)
         )
-        # Store current participant for user speech transcription events
-        self._current_participant: Participant | None = None
 
         # Background tool tasks — tracked to prevent GC and awaited on close
         self._tool_tasks: set[asyncio.Task[None]] = set()
@@ -167,7 +168,7 @@ class Realtime(OmniLLM):
         """Increment epoch so stale audio output events are discarded."""
         self._epoch += 1
         self._current_participant = None
-        self._clear_input_audio_pacer()
+        self._audio_input_processor.clear()
         self._output.clear()
 
     def _run_tool_in_background(self, coro: Coroutine[None, None, None]) -> None:
@@ -190,30 +191,10 @@ class Realtime(OmniLLM):
 
     async def process_audio(self, pcm: PcmData, participant: Participant) -> None:
         self._current_participant = participant
-        if self._input_audio_pacer is not None:
-            if not self.connected:
-                return
-            await self._input_audio_pacer.push(pcm, participant)
-            return
-        await self.simple_audio_response(pcm, participant)
+        await self._audio_input_processor.process_audio(pcm, participant)
 
-    async def _send_paced_audio(
-        self, pcm: PcmData, participant: Participant | None
-    ) -> None:
-        if not self.connected:
-            return
-        participant = participant or self._current_participant
-        if participant is None:
-            return
-        await self.simple_audio_response(pcm, participant)
-
-    def _clear_input_audio_pacer(self) -> None:
-        if self._input_audio_pacer is not None:
-            self._input_audio_pacer.clear()
-
-    async def _close_input_audio_pacer(self) -> None:
-        if self._input_audio_pacer is not None:
-            await self._input_audio_pacer.close()
+    async def _close_audio_input(self) -> None:
+        await self._audio_input_processor.close()
 
     async def stop_watching_video_track(self) -> None:
         """Optionally overridden by providers that support video input."""
@@ -238,7 +219,7 @@ class Realtime(OmniLLM):
     def _on_disconnected(self, reason: str | None = None, clean: bool = True):
         """Mark the session disconnected and emit RealtimeDisconnectedEvent."""
         self.connected = False
-        self._clear_input_audio_pacer()
+        self._audio_input_processor.clear()
         self.events.send(
             RealtimeDisconnectedEvent(
                 plugin_name=self.provider_name,

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -15,6 +15,10 @@ from vision_agents.core.llm.events import (
     RealtimeConnectedEvent,
     RealtimeDisconnectedEvent,
 )
+from vision_agents.core.utils.audio_input_pacer import (
+    AudioInputPacer,
+    AudioInputPacingConfig,
+)
 from vision_agents.core.utils.stream import Stream
 
 logger = logging.getLogger(__name__)
@@ -94,12 +98,22 @@ class Realtime(OmniLLM):
     def __init__(
         self,
         fps: int = 1,  # the number of video frames per second to send (for implementations that support setting fps)
+        input_audio_pacing: AudioInputPacingConfig | None = None,
     ):
         super().__init__()
         self.connected = False
 
         self.session_id = str(uuid.uuid4())
         self.fps = fps
+        self._input_audio_pacer: AudioInputPacer | None = (
+            AudioInputPacer(
+                input_audio_pacing,
+                self._send_paced_audio,
+                name=f"{self.provider_name}_input_pacer",
+            )
+            if input_audio_pacing is not None
+            else None
+        )
         # Store current participant for user speech transcription events
         self._current_participant: Participant | None = None
 
@@ -153,6 +167,7 @@ class Realtime(OmniLLM):
         """Increment epoch so stale audio output events are discarded."""
         self._epoch += 1
         self._current_participant = None
+        self._clear_input_audio_pacer()
         self._output.clear()
 
     def _run_tool_in_background(self, coro: Coroutine[None, None, None]) -> None:
@@ -175,7 +190,27 @@ class Realtime(OmniLLM):
 
     async def process_audio(self, pcm: PcmData, participant: Participant) -> None:
         self._current_participant = participant
+        if self._input_audio_pacer is not None:
+            if not self.connected:
+                return
+            await self._input_audio_pacer.push(pcm, participant)
+            return
         await self.simple_audio_response(pcm, participant)
+
+    async def _send_paced_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None:
+        if not self.connected:
+            return
+        await self.simple_audio_response(pcm, participant)
+
+    def _clear_input_audio_pacer(self) -> None:
+        if self._input_audio_pacer is not None:
+            self._input_audio_pacer.clear()
+
+    async def _close_input_audio_pacer(self) -> None:
+        if self._input_audio_pacer is not None:
+            await self._input_audio_pacer.close()
 
     async def stop_watching_video_track(self) -> None:
         """Optionally overridden by providers that support video input."""
@@ -200,6 +235,7 @@ class Realtime(OmniLLM):
     def _on_disconnected(self, reason: str | None = None, clean: bool = True):
         """Mark the session disconnected and emit RealtimeDisconnectedEvent."""
         self.connected = False
+        self._clear_input_audio_pacer()
         self.events.send(
             RealtimeDisconnectedEvent(
                 plugin_name=self.provider_name,

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -202,6 +202,9 @@ class Realtime(OmniLLM):
     ) -> None:
         if not self.connected:
             return
+        participant = participant or self._current_participant
+        if participant is None:
+            return
         await self.simple_audio_response(pcm, participant)
 
     def _clear_input_audio_pacer(self) -> None:

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -1,0 +1,29 @@
+from getstream.video.rtc.track_util import PcmData
+
+from ..edge.types import Participant
+from ..llm.llm import AudioLLM
+from .audio_input_processor import AudioInputProcessor
+
+
+class AudioInputDirect(AudioInputProcessor):
+    """Forward every PCM chunk straight to the audio LLM's provider.
+
+    Subclasses may override `process_audio` to add buffering/pacing and call
+    `super().process_audio(...)` to deliver each chunk through the default path.
+    """
+
+    def __init__(self, audio_llm: AudioLLM) -> None:
+        self._audio_llm = audio_llm
+
+    async def process_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None:
+        if participant is None:
+            return
+        await self._audio_llm.simple_audio_response(pcm, participant)
+
+    def clear(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -1,16 +1,15 @@
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
+from ..llm.llm import AudioLLM
+from .audio_input_direct import AudioInputDirect
 from .audio_queue import AudioQueue
 
 logger = logging.getLogger(__name__)
-
-AudioInputSender = Callable[[PcmData, Participant | None], Awaitable[None]]
 
 
 @dataclass(slots=True)
@@ -41,17 +40,17 @@ class AudioInputPacingConfig:
             raise ValueError("max_buffer_ms must be at least startup_buffer_ms")
 
 
-class AudioInputPacer:
+class AudioInputPacer(AudioInputDirect):
     """Buffers input audio and forwards it at a stable wall-clock cadence."""
 
     def __init__(
         self,
+        audio_llm: AudioLLM,
         config: AudioInputPacingConfig,
-        send: AudioInputSender,
         name: str = "audio_input_pacer",
     ) -> None:
+        super().__init__(audio_llm)
         self.config = config
-        self._send = send
         self._name = name
         self._queue = AudioQueue(buffer_limit_ms=int(config.max_buffer_ms))
         self._task: asyncio.Task[None] | None = None
@@ -62,7 +61,9 @@ class AudioInputPacer:
         self.pauses = 0
         self._generation = 0
 
-    async def push(self, pcm: PcmData, participant: Participant | None) -> None:
+    async def process_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None:
         """Add audio to the pacing buffer, resampling to the configured format."""
         self.start()
         self._participant = participant
@@ -122,8 +123,10 @@ class AudioInputPacer:
                 if generation != self._generation:
                     continue
 
+                if not self._audio_llm.connected:
+                    continue
                 try:
-                    await self._send(chunk, chunk.participant)
+                    await super().process_audio(chunk, chunk.participant)
                 except Exception:
                     logger.exception("%s send failed", self._name)
                     continue
@@ -139,8 +142,6 @@ class AudioInputPacer:
                         self.pauses,
                         self.buffered_ms(),
                     )
-        except asyncio.CancelledError:
-            raise
         except Exception:
             logger.exception("%s stopped unexpectedly", self._name)
 

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -1,0 +1,174 @@
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from getstream.video.rtc.track_util import PcmData
+
+from ..edge.types import Participant
+from .audio_queue import AudioQueue
+
+logger = logging.getLogger(__name__)
+
+AudioInputSender = Callable[[PcmData, Participant | None], Awaitable[None]]
+
+
+@dataclass(slots=True)
+class AudioInputPacingConfig:
+    """Configuration for steady realtime audio input forwarding."""
+
+    sample_rate: int = 16000
+    channels: int = 1
+    chunk_ms: float = 20.0
+    startup_buffer_ms: float = 300.0
+    max_buffer_ms: float = 1500.0
+    silence_when_empty: bool = False
+
+    @classmethod
+    def virtual_microphone(cls) -> "AudioInputPacingConfig":
+        return cls(startup_buffer_ms=500.0, silence_when_empty=True)
+
+    def __post_init__(self) -> None:
+        if self.sample_rate <= 0:
+            raise ValueError("sample_rate must be positive")
+        if self.channels <= 0:
+            raise ValueError("channels must be positive")
+        if self.chunk_ms <= 0:
+            raise ValueError("chunk_ms must be positive")
+        if self.startup_buffer_ms < self.chunk_ms:
+            raise ValueError("startup_buffer_ms must be at least chunk_ms")
+        if self.max_buffer_ms < self.startup_buffer_ms:
+            raise ValueError("max_buffer_ms must be at least startup_buffer_ms")
+
+
+class AudioInputPacer:
+    """Buffers input audio and forwards it at a stable wall-clock cadence."""
+
+    def __init__(
+        self,
+        config: AudioInputPacingConfig,
+        send: AudioInputSender,
+        name: str = "audio_input_pacer",
+    ) -> None:
+        self.config = config
+        self._send = send
+        self._name = name
+        self._queue = AudioQueue(buffer_limit_ms=int(config.max_buffer_ms))
+        self._task: asyncio.Task[None] | None = None
+        self._streaming = False
+        self._participant: Participant | None = None
+        self.chunks_sent = 0
+        self.silence_chunks_sent = 0
+        self.pauses = 0
+
+    async def push(self, pcm: PcmData, participant: Participant | None) -> None:
+        """Add audio to the pacing buffer, resampling to the configured format."""
+        self.start()
+        self._participant = participant
+        audio = pcm.resample(
+            target_sample_rate=self.config.sample_rate,
+            target_channels=self.config.channels,
+        ).to_int16()
+        if audio.duration_ms > self.config.max_buffer_ms:
+            audio = audio.tail(self.config.max_buffer_ms / 1000)
+        audio.participant = participant
+        await self._queue.put(audio)
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._run())
+
+    def clear(self) -> None:
+        self._streaming = False
+        self._participant = None
+        self._queue.clear()
+
+    async def close(self) -> None:
+        self.clear()
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    def buffered_ms(self) -> float:
+        return float(self._queue.get_buffer_info()["current_duration_ms"])
+
+    async def _run(self) -> None:
+        interval = self.config.chunk_ms / 1000
+        loop = asyncio.get_running_loop()
+        next_t = loop.time()
+        try:
+            while True:
+                next_t += interval
+                delay = next_t - loop.time()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                elif delay < -1.0:
+                    next_t = loop.time()
+
+                if not self._ready_to_send():
+                    continue
+
+                chunk = await self._next_chunk()
+                if chunk is None:
+                    continue
+
+                try:
+                    await self._send(chunk, chunk.participant)
+                except Exception:
+                    logger.exception("%s send failed", self._name)
+                    continue
+
+                self.chunks_sent += 1
+
+                if self.chunks_sent % 500 == 0:
+                    logger.info(
+                        "%s forwarded %d chunks, silence=%d, pauses=%d, buffered=%.0fms",
+                        self._name,
+                        self.chunks_sent,
+                        self.silence_chunks_sent,
+                        self.pauses,
+                        self.buffered_ms(),
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("%s stopped unexpectedly", self._name)
+
+    async def _next_chunk(self) -> PcmData | None:
+        if self.buffered_ms() >= self.config.chunk_ms:
+            try:
+                return await self._queue.get_duration(self.config.chunk_ms)
+            except asyncio.QueueEmpty:
+                return None
+
+        if not self.config.silence_when_empty:
+            return None
+
+        samples = int(self.config.sample_rate * self.config.chunk_ms / 1000)
+        silence = PcmData.from_bytes(
+            b"\x00" * samples * self.config.channels * 2,
+            sample_rate=self.config.sample_rate,
+            channels=self.config.channels,
+        )
+        silence.participant = self._participant
+        self.silence_chunks_sent += 1
+        return silence
+
+    def _ready_to_send(self) -> bool:
+        buffered_ms = self.buffered_ms()
+        if self._streaming:
+            if self.config.silence_when_empty or buffered_ms >= self.config.chunk_ms:
+                return True
+            self._streaming = False
+            self.pauses += 1
+            return False
+
+        if buffered_ms >= self.config.startup_buffer_ms:
+            self._streaming = True
+            return True
+        return False

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -60,6 +60,7 @@ class AudioInputPacer:
         self.chunks_sent = 0
         self.silence_chunks_sent = 0
         self.pauses = 0
+        self._generation = 0
 
     async def push(self, pcm: PcmData, participant: Participant | None) -> None:
         """Add audio to the pacing buffer, resampling to the configured format."""
@@ -79,6 +80,7 @@ class AudioInputPacer:
             self._task = asyncio.create_task(self._run())
 
     def clear(self) -> None:
+        self._generation += 1
         self._streaming = False
         self._participant = None
         self._queue.clear()
@@ -113,8 +115,11 @@ class AudioInputPacer:
                 if not self._ready_to_send():
                     continue
 
+                generation = self._generation
                 chunk = await self._next_chunk()
                 if chunk is None:
+                    continue
+                if generation != self._generation:
                     continue
 
                 try:

--- a/agents-core/vision_agents/core/utils/audio_input_processor.py
+++ b/agents-core/vision_agents/core/utils/audio_input_processor.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+from getstream.video.rtc.track_util import PcmData
+
+from ..edge.types import Participant
+
+
+class AudioInputProcessor(ABC):
+    """Abstract handler for the input-audio path between Realtime.process_audio and the provider."""
+
+    @abstractmethod
+    async def process_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None: ...
+
+    @abstractmethod
+    def clear(self) -> None: ...
+
+    @abstractmethod
+    async def close(self) -> None: ...

--- a/agents-core/vision_agents/core/utils/audio_queue.py
+++ b/agents-core/vision_agents/core/utils/audio_queue.py
@@ -225,6 +225,7 @@ class AudioQueue:
                         sample_rate=item.sample_rate,
                         format=item.format,
                         channels=item.channels,
+                        participant=item.participant,
                     )
                     self._buffer.appendleft(remainder)
                     self._total_samples += len(remainder.samples)

--- a/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
+++ b/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
@@ -824,6 +824,7 @@ class Realtime(realtime.Realtime, Warmable[SileroVADSessionPool]):
         await self.content_end(content_name)
 
     async def close(self):
+        await self._close_input_audio_pacer()
         if not self.connected:
             return
 

--- a/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
+++ b/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
@@ -824,7 +824,7 @@ class Realtime(realtime.Realtime, Warmable[SileroVADSessionPool]):
         await self.content_end(content_name)
 
     async def close(self):
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
         if not self.connected:
             return
 

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -28,6 +28,8 @@ from vision_agents.core.llm.realtime import (
     RealtimeUserSpeechStarted,
     RealtimeUserTranscript,
 )
+from vision_agents.core.utils.audio_input_pacer import AudioInputPacer
+from vision_agents.core.utils.audio_input_direct import AudioInputDirect
 from vision_agents.plugins.gemini import Realtime
 from vision_agents.plugins.gemini.gemini_realtime import (
     DEFAULT_MODEL,
@@ -76,11 +78,11 @@ class TestGeminiRealtimeInputPacing:
 
         assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
         assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"
-        assert default_rt._input_audio_pacer is None
-        assert translate_rt._input_audio_pacer is not None
-        assert translate_rt._input_audio_pacer.config.silence_when_empty
-        assert translate_rt._input_audio_pacer.config.startup_buffer_ms == 500
-        assert translate_opt_out._input_audio_pacer is None
+        assert type(default_rt._audio_input_processor) is AudioInputDirect
+        assert isinstance(translate_rt._audio_input_processor, AudioInputPacer)
+        assert translate_rt._audio_input_processor.config.silence_when_empty
+        assert translate_rt._audio_input_processor.config.startup_buffer_ms == 500
+        assert type(translate_opt_out._audio_input_processor) is AudioInputDirect
 
 
 class TestGeminiRealtimeProcessEvents:

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -1,6 +1,6 @@
 import asyncio
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 import websockets
@@ -52,26 +52,27 @@ def _make_session(messages: list[LiveServerMessage]) -> AsyncMock:
     return session
 
 
+def _fake_client() -> Any:
+    return object()
+
+
 def _make_realtime() -> GeminiRealtime:
     """Create a GeminiRealtime instance without connecting."""
-    with patch("vision_agents.plugins.gemini.gemini_realtime.genai"):
-        rt = GeminiRealtime(api_key="fake-key")
-    return rt
+    return GeminiRealtime(client=_fake_client())
 
 
 class TestGeminiRealtimeInputPacing:
     def test_default_model_and_live_translate_pacing_policy(self):
-        with patch("vision_agents.plugins.gemini.gemini_realtime.genai"):
-            default_rt = GeminiRealtime(api_key="fake-key")
-            translate_rt = GeminiRealtime(
-                model=LIVE_TRANSLATE_MODEL,
-                api_key="fake-key",
-            )
-            translate_opt_out = GeminiRealtime(
-                model=LIVE_TRANSLATE_MODEL,
-                api_key="fake-key",
-                input_audio_pacing=None,
-            )
+        default_rt = GeminiRealtime(client=_fake_client())
+        translate_rt = GeminiRealtime(
+            model=LIVE_TRANSLATE_MODEL,
+            client=_fake_client(),
+        )
+        translate_opt_out = GeminiRealtime(
+            model=LIVE_TRANSLATE_MODEL,
+            client=_fake_client(),
+            input_audio_pacing=None,
+        )
 
         assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
         assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -29,7 +29,11 @@ from vision_agents.core.llm.realtime import (
     RealtimeUserTranscript,
 )
 from vision_agents.plugins.gemini import Realtime
-from vision_agents.plugins.gemini.gemini_realtime import GeminiRealtime
+from vision_agents.plugins.gemini.gemini_realtime import (
+    DEFAULT_MODEL,
+    LIVE_TRANSLATE_MODEL,
+    GeminiRealtime,
+)
 from websockets.frames import Close
 
 # Load environment variables
@@ -53,6 +57,29 @@ def _make_realtime() -> GeminiRealtime:
     with patch("vision_agents.plugins.gemini.gemini_realtime.genai"):
         rt = GeminiRealtime(api_key="fake-key")
     return rt
+
+
+class TestGeminiRealtimeInputPacing:
+    def test_default_model_and_live_translate_pacing_policy(self):
+        with patch("vision_agents.plugins.gemini.gemini_realtime.genai"):
+            default_rt = GeminiRealtime(api_key="fake-key")
+            translate_rt = GeminiRealtime(
+                model=LIVE_TRANSLATE_MODEL,
+                api_key="fake-key",
+            )
+            translate_opt_out = GeminiRealtime(
+                model=LIVE_TRANSLATE_MODEL,
+                api_key="fake-key",
+                input_audio_pacing=None,
+            )
+
+        assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
+        assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"
+        assert default_rt._input_audio_pacer is None
+        assert translate_rt._input_audio_pacer is not None
+        assert translate_rt._input_audio_pacer.config.silence_when_empty
+        assert translate_rt._input_audio_pacer.config.startup_buffer_ms == 500
+        assert translate_opt_out._input_audio_pacer is None
 
 
 class TestGeminiRealtimeProcessEvents:

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -50,7 +50,8 @@ from .file_search import FileSearchStore
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
+DEFAULT_MODEL = "gemini-3.1-flash-live-preview"
+LIVE_TRANSLATE_MODEL = "gemini-3.5-live-translate-preview"
 
 DEFAULT_CONFIG = LiveConnectConfigDict(
     response_modalities=[Modality.AUDIO],
@@ -72,7 +73,6 @@ DEFAULT_CONFIG = LiveConnectConfigDict(
             prefix_padding_ms=50,
         ),
     ),
-    enable_affective_dialog=False,
     context_window_compression=ContextWindowCompressionConfigDict(
         trigger_tokens=25600,
         sliding_window=SlidingWindowDict(target_tokens=12800),
@@ -117,6 +117,10 @@ def _classify_loop_error(exc: Exception) -> tuple[str, str, bool]:
             return STOP, f"API error code {code}", False
 
     return RETRY, str(exc), False
+
+
+def _needs_input_audio_pacing(model: str) -> bool:
+    return model.lower() == LIVE_TRANSLATE_MODEL
 
 
 class GeminiRealtime(realtime.Realtime):
@@ -170,6 +174,11 @@ class GeminiRealtime(realtime.Realtime):
                 See: https://ai.google.dev/gemini-api/docs/file-search
             **kwargs: Additional arguments passed to parent class.
         """
+        if "input_audio_pacing" not in kwargs and _needs_input_audio_pacing(model):
+            kwargs["input_audio_pacing"] = (
+                realtime.AudioInputPacingConfig.virtual_microphone()
+            )
+
         super().__init__(**kwargs)
         self.model = model
         self.connected: bool = False
@@ -358,6 +367,7 @@ class GeminiRealtime(realtime.Realtime):
 
         """
         self._on_disconnected()
+        await self._close_input_audio_pacer()
 
         await self.stop_watching_video_track()
 

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -367,7 +367,7 @@ class GeminiRealtime(realtime.Realtime):
 
         """
         self._on_disconnected()
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
 
         await self.stop_watching_video_track()
 

--- a/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
@@ -236,7 +236,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(audio)
 
     async def close(self) -> None:
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
         await self._await_pending_tools()
         self._pending_tool_calls.clear()
         await self.rtc.close()

--- a/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
@@ -236,6 +236,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(audio)
 
     async def close(self) -> None:
+        await self._close_input_audio_pacer()
         await self._await_pending_tools()
         self._pending_tool_calls.clear()
         await self.rtc.close()

--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -191,6 +191,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(pcm)
 
     async def close(self):
+        await self._close_input_audio_pacer()
         await self._await_pending_tools()
         await self.rtc.close()
         self._on_disconnected()

--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -191,7 +191,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(pcm)
 
     async def close(self):
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
         await self._await_pending_tools()
         await self.rtc.close()
         self._on_disconnected()

--- a/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
+++ b/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
@@ -126,7 +126,7 @@ class Qwen3Realtime(Realtime):
 
     async def close(self):
         self._on_disconnected()
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
         await self.stop_watching_video_track()
         if self._processing_task is not None:
             self._processing_task.cancel()

--- a/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
+++ b/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
@@ -126,6 +126,7 @@ class Qwen3Realtime(Realtime):
 
     async def close(self):
         self._on_disconnected()
+        await self._close_input_audio_pacer()
         await self.stop_watching_video_track()
         if self._processing_task is not None:
             self._processing_task.cancel()

--- a/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
+++ b/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
@@ -324,7 +324,7 @@ class XAIRealtime(realtime.Realtime):
     async def close(self):
         """Close the connection and clean up resources."""
         self._on_disconnected()
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
 
         await self._await_pending_tools()
 

--- a/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
+++ b/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
@@ -324,6 +324,7 @@ class XAIRealtime(realtime.Realtime):
     async def close(self):
         """Close the connection and clean up resources."""
         self._on_disconnected()
+        await self._close_input_audio_pacer()
 
         await self._await_pending_tools()
 

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -1,0 +1,118 @@
+import asyncio
+from collections.abc import AsyncIterator
+
+import numpy as np
+from getstream.video.rtc.track_util import AudioFormat, PcmData
+from vision_agents.core.edge.types import Participant
+from vision_agents.core.llm.llm import LLMResponseDelta, LLMResponseFinal
+from vision_agents.core.llm.realtime import Realtime
+from vision_agents.core.utils.audio_input_pacer import (
+    AudioInputPacer,
+    AudioInputPacingConfig,
+)
+
+from tests.base_test import BaseTest
+
+
+def _pcm(value: int, duration_ms: float, sample_rate: int = 16000) -> PcmData:
+    samples = np.full(int(sample_rate * duration_ms / 1000), value, dtype=np.int16)
+    return PcmData(
+        samples=samples,
+        sample_rate=sample_rate,
+        format=AudioFormat.S16,
+        channels=1,
+    )
+
+
+async def _wait_until(predicate, timeout: float = 0.25) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.002)
+    raise AssertionError("condition was not met before timeout")
+
+
+class _RealtimeForPacingTest(Realtime):
+    provider_name = "test_realtime"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.sent: list[PcmData] = []
+
+    async def connect(self):
+        self._on_connected()
+
+    async def simple_response(
+        self,
+        text: str,
+        participant: Participant | None = None,
+    ) -> AsyncIterator[LLMResponseDelta | LLMResponseFinal]:
+        yield LLMResponseFinal()
+
+    async def simple_audio_response(
+        self, pcm: PcmData, participant: Participant | None = None
+    ):
+        self.sent.append(pcm)
+
+    async def watch_video_track(self, *args, **kwargs) -> None:
+        pass
+
+    async def close(self) -> None:
+        await self._close_input_audio_pacer()
+        self._on_disconnected()
+
+
+class TestAudioInputPacer(BaseTest):
+    async def test_realtime_process_audio_uses_configured_pacer(self):
+        participant = Participant(original=None, user_id="u", id="u")
+        realtime = _RealtimeForPacingTest(
+            input_audio_pacing=AudioInputPacingConfig(
+                chunk_ms=5,
+                startup_buffer_ms=10,
+                max_buffer_ms=100,
+            )
+        )
+        await realtime.connect()
+
+        try:
+            await realtime.process_audio(_pcm(1, 5), participant)
+            await asyncio.sleep(0.02)
+            assert realtime.sent == []
+
+            await realtime.process_audio(_pcm(2, 5), participant)
+            await _wait_until(lambda: len(realtime.sent) >= 1)
+            assert realtime.sent[0].duration_ms == 5
+        finally:
+            await realtime.close()
+
+    async def test_virtual_microphone_fills_silence_after_prime(self):
+        sent: list[PcmData] = []
+
+        async def send(pcm: PcmData, participant):
+            sent.append(pcm)
+
+        pacer = AudioInputPacer(
+            AudioInputPacingConfig(
+                chunk_ms=5,
+                startup_buffer_ms=10,
+                max_buffer_ms=100,
+                silence_when_empty=True,
+            ),
+            send,
+        )
+
+        try:
+            await pacer.push(_pcm(3, 10), None)
+            await _wait_until(lambda: len(sent) >= 3)
+            assert np.all(sent[0].samples == 3)
+            assert np.all(sent[1].samples == 3)
+            assert any(np.all(chunk.samples == 0) for chunk in sent[2:])
+            assert pacer.silence_chunks_sent > 0
+
+            pacer.clear()
+            sent_after_clear = len(sent)
+            await asyncio.sleep(0.02)
+            assert len(sent) == sent_after_clear
+        finally:
+            await pacer.close()

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -60,7 +60,7 @@ class _RealtimeForPacingTest(Realtime):
         pass
 
     async def close(self) -> None:
-        await self._close_input_audio_pacer()
+        await self._close_audio_input()
         self._on_disconnected()
 
 
@@ -106,58 +106,54 @@ class TestAudioInputPacer(BaseTest):
             await realtime.close()
 
     async def test_virtual_microphone_fills_silence_after_prime(self):
-        sent: list[PcmData] = []
-
-        async def send(pcm: PcmData, participant):
-            sent.append(pcm)
-
+        participant = Participant(original=None, user_id="u", id="u")
+        realtime = _RealtimeForPacingTest()
+        await realtime.connect()
         pacer = AudioInputPacer(
+            realtime,
             AudioInputPacingConfig(
                 chunk_ms=5,
                 startup_buffer_ms=10,
                 max_buffer_ms=100,
                 silence_when_empty=True,
             ),
-            send,
         )
 
         try:
-            await pacer.push(_pcm(3, 10), None)
-            await _wait_until(lambda: len(sent) >= 3)
-            assert np.all(sent[0].samples == 3)
-            assert np.all(sent[1].samples == 3)
-            assert any(np.all(chunk.samples == 0) for chunk in sent[2:])
+            await pacer.process_audio(_pcm(3, 10), participant)
+            await _wait_until(lambda: len(realtime.sent) >= 3)
+            assert np.all(realtime.sent[0].samples == 3)
+            assert np.all(realtime.sent[1].samples == 3)
+            assert any(np.all(chunk.samples == 0) for chunk in realtime.sent[2:])
             assert pacer.silence_chunks_sent > 0
 
             pacer.clear()
-            sent_after_clear = len(sent)
+            sent_after_clear = len(realtime.sent)
             await asyncio.sleep(0.02)
-            assert len(sent) == sent_after_clear
+            assert len(realtime.sent) == sent_after_clear
         finally:
             await pacer.close()
 
     async def test_clear_during_chunk_fetch_drops_stale_chunk(self):
-        sent: list[PcmData] = []
-
-        async def send(pcm: PcmData, participant):
-            sent.append(pcm)
-
+        participant = Participant(original=None, user_id="u", id="u")
+        realtime = _RealtimeForPacingTest()
+        await realtime.connect()
         pacer = AudioInputPacer(
+            realtime,
             AudioInputPacingConfig(
                 chunk_ms=5,
                 startup_buffer_ms=5,
                 max_buffer_ms=100,
             ),
-            send,
         )
         queue = _ClearingAudioQueue(pacer, _pcm(4, 5))
         pacer._queue = queue
 
         try:
-            pacer.start()
+            await pacer.process_audio(_pcm(4, 5), participant)
             await _wait_until(lambda: queue.was_cleared)
             await asyncio.sleep(0.02)
-            assert sent == []
+            assert realtime.sent == []
             assert pacer.chunks_sent == 0
         finally:
             await pacer.close()

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -10,6 +10,7 @@ from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacer,
     AudioInputPacingConfig,
 )
+from vision_agents.core.utils.audio_queue import AudioQueue
 
 from tests.base_test import BaseTest
 
@@ -63,6 +64,24 @@ class _RealtimeForPacingTest(Realtime):
         self._on_disconnected()
 
 
+class _ClearingAudioQueue(AudioQueue):
+    def __init__(self, pacer: AudioInputPacer, chunk: PcmData) -> None:
+        super().__init__(buffer_limit_ms=100)
+        self._pacer = pacer
+        self._chunk = chunk
+        self.was_cleared = False
+
+    def clear(self) -> None:
+        self.was_cleared = True
+
+    def get_buffer_info(self) -> dict:
+        return {"current_duration_ms": 0 if self.was_cleared else 10}
+
+    async def get_duration(self, duration_ms: float) -> PcmData:
+        self._pacer.clear()
+        return self._chunk
+
+
 class TestAudioInputPacer(BaseTest):
     async def test_realtime_process_audio_uses_configured_pacer(self):
         participant = Participant(original=None, user_id="u", id="u")
@@ -114,5 +133,31 @@ class TestAudioInputPacer(BaseTest):
             sent_after_clear = len(sent)
             await asyncio.sleep(0.02)
             assert len(sent) == sent_after_clear
+        finally:
+            await pacer.close()
+
+    async def test_clear_during_chunk_fetch_drops_stale_chunk(self):
+        sent: list[PcmData] = []
+
+        async def send(pcm: PcmData, participant):
+            sent.append(pcm)
+
+        pacer = AudioInputPacer(
+            AudioInputPacingConfig(
+                chunk_ms=5,
+                startup_buffer_ms=5,
+                max_buffer_ms=100,
+            ),
+            send,
+        )
+        queue = _ClearingAudioQueue(pacer, _pcm(4, 5))
+        pacer._queue = queue
+
+        try:
+            pacer.start()
+            await _wait_until(lambda: queue.was_cleared)
+            await asyncio.sleep(0.02)
+            assert sent == []
+            assert pacer.chunks_sent == 0
         finally:
             await pacer.close()


### PR DESCRIPTION
## Summary

  Adds an opt-in realtime input audio pacer to the framework and enables virtual-microphone pacing for Gemini Live Translate.

  ## Why
Gemini Live Translate was producing audible jitter/silence when upstream audio arrived unevenly. The working solution called for sending fixed 20 ms chunks on a wall-clock cadence, waits for an initial buffer, and fills silence after priming when no real audio is buffered. With gaps in the buffer or cases where silence is not added leads to jittery output from the model. 

  ## Changes

  - Add `AudioInputPacingConfig` and `AudioInputPacer` for realtime audio input pacing.
  - Wire optional input pacing into the base `Realtime` class.
  - Clear/close configured pacers during interrupts, disconnects, and provider shutdown.
  - Update Gemini default model to `gemini-3.1-flash-live-preview`.
  - Add `gemini-3.5-live-translate-preview` as the Live Translate model and auto-enable virtual-microphone pacing for that model.
  - Add focused tests for the framework pacer and Gemini pacing policy.

  ## Validation

  - `uv run pytest tests/test_audio_input_pacer.py plugins/gemini/tests/test_gemini_realtime.py::TestGeminiRealtimeInputPacing`
  - `uv run pytest plugins/gemini/tests/test_gemini_realtime.py -m "not integration"`
  - Manual realtime smoke tests:
    - Gemini Live Translate: passed
    - Gemini Live: passed
    - OpenAI Realtime: passed
    - xAI Realtime: passed
    - Inworld Realtime: passed