### PR TITLE
refactor: clean up realtime input audio handling

### DIFF
--- a/agents-core/vision_agents/core/llm/llm.py
+++ b/agents-core/vision_agents/core/llm/llm.py
@@ -468,6 +468,8 @@ class AudioLLM(LLM, metaclass=abc.ABCMeta):
     These models do not require TTS and STT services to run.
     """
 
+    connected: bool = False
+
     @abc.abstractmethod
     async def simple_audio_response(self, pcm: PcmData, participant: Participant):
         """

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -20,7 +20,7 @@ from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacingConfig,
 )
 from vision_agents.core.utils.audio_input_processor import AudioInputProcessor
-from vision_agents.core.utils.audio_input_direct import DirectInput
+from vision_agents.core.utils.audio_input_direct import AudioInputDirect
 from vision_agents.core.utils.stream import Stream
 
 logger = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class Realtime(OmniLLM):
                 name=f"{self.provider_name}_input_pacer",
             )
             if input_audio_pacing is not None
-            else DirectInput(self)
+            else AudioInputDirect(self)
         )
 
         # Background tool tasks — tracked to prevent GC and awaited on close
@@ -193,7 +193,7 @@ class Realtime(OmniLLM):
         self._current_participant = participant
         await self._audio_input_processor.process_audio(pcm, participant)
 
-    async def _close_input_audio(self) -> None:
+    async def _close_audio_input(self) -> None:
         await self._audio_input_processor.close()
 
     async def stop_watching_video_track(self) -> None:

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -19,10 +19,8 @@ from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacer,
     AudioInputPacingConfig,
 )
-from vision_agents.core.utils.audio_input_sender import (
-    AudioInputSender,
-    DirectInput,
-)
+from vision_agents.core.utils.audio_input_sender import AudioInputSender
+from vision_agents.core.utils.audio_input_direct import DirectInput
 from vision_agents.core.utils.stream import Stream
 
 logger = logging.getLogger(__name__)

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -18,6 +18,8 @@ from vision_agents.core.llm.events import (
 from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacer,
     AudioInputPacingConfig,
+    DirectInput,
+    InputAudioStrategy,
 )
 from vision_agents.core.utils.stream import Stream
 
@@ -105,17 +107,18 @@ class Realtime(OmniLLM):
 
         self.session_id = str(uuid.uuid4())
         self.fps = fps
-        self._input_audio_pacer: AudioInputPacer | None = (
+        # Store current participant for user speech transcription events
+        self._current_participant: Participant | None = None
+
+        self._input_audio: InputAudioStrategy = (
             AudioInputPacer(
+                self,
                 input_audio_pacing,
-                self._send_paced_audio,
                 name=f"{self.provider_name}_input_pacer",
             )
             if input_audio_pacing is not None
-            else None
+            else DirectInput(self)
         )
-        # Store current participant for user speech transcription events
-        self._current_participant: Participant | None = None
 
         # Background tool tasks — tracked to prevent GC and awaited on close
         self._tool_tasks: set[asyncio.Task[None]] = set()
@@ -167,7 +170,7 @@ class Realtime(OmniLLM):
         """Increment epoch so stale audio output events are discarded."""
         self._epoch += 1
         self._current_participant = None
-        self._clear_input_audio_pacer()
+        self._input_audio.clear()
         self._output.clear()
 
     def _run_tool_in_background(self, coro: Coroutine[None, None, None]) -> None:
@@ -190,30 +193,10 @@ class Realtime(OmniLLM):
 
     async def process_audio(self, pcm: PcmData, participant: Participant) -> None:
         self._current_participant = participant
-        if self._input_audio_pacer is not None:
-            if not self.connected:
-                return
-            await self._input_audio_pacer.push(pcm, participant)
-            return
-        await self.simple_audio_response(pcm, participant)
+        await self._input_audio.send(pcm, participant)
 
-    async def _send_paced_audio(
-        self, pcm: PcmData, participant: Participant | None
-    ) -> None:
-        if not self.connected:
-            return
-        participant = participant or self._current_participant
-        if participant is None:
-            return
-        await self.simple_audio_response(pcm, participant)
-
-    def _clear_input_audio_pacer(self) -> None:
-        if self._input_audio_pacer is not None:
-            self._input_audio_pacer.clear()
-
-    async def _close_input_audio_pacer(self) -> None:
-        if self._input_audio_pacer is not None:
-            await self._input_audio_pacer.close()
+    async def _close_input_audio(self) -> None:
+        await self._input_audio.close()
 
     async def stop_watching_video_track(self) -> None:
         """Optionally overridden by providers that support video input."""
@@ -238,7 +221,7 @@ class Realtime(OmniLLM):
     def _on_disconnected(self, reason: str | None = None, clean: bool = True):
         """Mark the session disconnected and emit RealtimeDisconnectedEvent."""
         self.connected = False
-        self._clear_input_audio_pacer()
+        self._input_audio.clear()
         self.events.send(
             RealtimeDisconnectedEvent(
                 plugin_name=self.provider_name,

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -103,8 +103,6 @@ class Realtime(OmniLLM):
         input_audio_pacing: AudioInputPacingConfig | None = None,
     ):
         super().__init__()
-        self.connected = False
-
         self.session_id = str(uuid.uuid4())
         self.fps = fps
         # Store current participant for user speech transcription events

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -18,8 +18,10 @@ from vision_agents.core.llm.events import (
 from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacer,
     AudioInputPacingConfig,
+)
+from vision_agents.core.utils.audio_input_sender import (
+    AudioInputSender,
     DirectInput,
-    InputAudioStrategy,
 )
 from vision_agents.core.utils.stream import Stream
 
@@ -110,7 +112,7 @@ class Realtime(OmniLLM):
         # Store current participant for user speech transcription events
         self._current_participant: Participant | None = None
 
-        self._input_audio: InputAudioStrategy = (
+        self._audio_input_sender: AudioInputSender = (
             AudioInputPacer(
                 self,
                 input_audio_pacing,
@@ -170,7 +172,7 @@ class Realtime(OmniLLM):
         """Increment epoch so stale audio output events are discarded."""
         self._epoch += 1
         self._current_participant = None
-        self._input_audio.clear()
+        self._audio_input_sender.clear()
         self._output.clear()
 
     def _run_tool_in_background(self, coro: Coroutine[None, None, None]) -> None:
@@ -193,10 +195,10 @@ class Realtime(OmniLLM):
 
     async def process_audio(self, pcm: PcmData, participant: Participant) -> None:
         self._current_participant = participant
-        await self._input_audio.send(pcm, participant)
+        await self._audio_input_sender.send(pcm, participant)
 
     async def _close_input_audio(self) -> None:
-        await self._input_audio.close()
+        await self._audio_input_sender.close()
 
     async def stop_watching_video_track(self) -> None:
         """Optionally overridden by providers that support video input."""
@@ -221,7 +223,7 @@ class Realtime(OmniLLM):
     def _on_disconnected(self, reason: str | None = None, clean: bool = True):
         """Mark the session disconnected and emit RealtimeDisconnectedEvent."""
         self.connected = False
-        self._input_audio.clear()
+        self._audio_input_sender.clear()
         self.events.send(
             RealtimeDisconnectedEvent(
                 plugin_name=self.provider_name,

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -19,7 +19,7 @@ from vision_agents.core.utils.audio_input_pacer import (
     AudioInputPacer,
     AudioInputPacingConfig,
 )
-from vision_agents.core.utils.audio_input_sender import AudioInputSender
+from vision_agents.core.utils.audio_input_processor import AudioInputProcessor
 from vision_agents.core.utils.audio_input_direct import DirectInput
 from vision_agents.core.utils.stream import Stream
 
@@ -108,7 +108,7 @@ class Realtime(OmniLLM):
         # Store current participant for user speech transcription events
         self._current_participant: Participant | None = None
 
-        self._audio_input_sender: AudioInputSender = (
+        self._audio_input_processor: AudioInputProcessor = (
             AudioInputPacer(
                 self,
                 input_audio_pacing,
@@ -168,7 +168,7 @@ class Realtime(OmniLLM):
         """Increment epoch so stale audio output events are discarded."""
         self._epoch += 1
         self._current_participant = None
-        self._audio_input_sender.clear()
+        self._audio_input_processor.clear()
         self._output.clear()
 
     def _run_tool_in_background(self, coro: Coroutine[None, None, None]) -> None:
@@ -191,10 +191,10 @@ class Realtime(OmniLLM):
 
     async def process_audio(self, pcm: PcmData, participant: Participant) -> None:
         self._current_participant = participant
-        await self._audio_input_sender.send(pcm, participant)
+        await self._audio_input_processor.process_audio(pcm, participant)
 
     async def _close_input_audio(self) -> None:
-        await self._audio_input_sender.close()
+        await self._audio_input_processor.close()
 
     async def stop_watching_video_track(self) -> None:
         """Optionally overridden by providers that support video input."""
@@ -219,7 +219,7 @@ class Realtime(OmniLLM):
     def _on_disconnected(self, reason: str | None = None, clean: bool = True):
         """Mark the session disconnected and emit RealtimeDisconnectedEvent."""
         self.connected = False
-        self._audio_input_sender.clear()
+        self._audio_input_processor.clear()
         self.events.send(
             RealtimeDisconnectedEvent(
                 plugin_name=self.provider_name,

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -6,21 +6,21 @@ from .audio_input_sender import AudioInputSender
 
 
 class DirectInput(AudioInputSender):
-    """Forward every PCM chunk straight to the host's provider.
+    """Forward every PCM chunk straight to the audio LLM's provider.
 
     Subclasses may override `send` to add buffering/pacing and call
     `super().send(...)` to deliver each chunk through the default path.
     """
 
-    def __init__(self, host: AudioLLM) -> None:
-        self._host = host
+    def __init__(self, audio_llm: AudioLLM) -> None:
+        self._audio_llm = audio_llm
 
     async def send(self, pcm: PcmData, participant: Participant | None) -> None:
-        if not self._host.connected:
+        if not self._audio_llm.connected:
             return
         if participant is None:
             return
-        await self._host.simple_audio_response(pcm, participant)
+        await self._audio_llm.simple_audio_response(pcm, participant)
 
     def clear(self) -> None:
         pass

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -5,7 +5,7 @@ from ..llm.llm import AudioLLM
 from .audio_input_processor import AudioInputProcessor
 
 
-class DirectInput(AudioInputProcessor):
+class AudioInputDirect(AudioInputProcessor):
     """Forward every PCM chunk straight to the audio LLM's provider.
 
     Subclasses may override `process_audio` to add buffering/pacing and call

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -1,0 +1,28 @@
+from getstream.video.rtc.track_util import PcmData
+
+from ..edge.types import Participant
+from .audio_input_sender import AudioInputHost, AudioInputSender
+
+
+class DirectInput(AudioInputSender):
+    """Forward every PCM chunk straight to the host's provider.
+
+    Subclasses may override `send` to add buffering/pacing and call
+    `super().send(...)` to deliver each chunk through the default path.
+    """
+
+    def __init__(self, host: AudioInputHost) -> None:
+        self._host = host
+
+    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
+        if not self._host.connected:
+            return
+        if participant is None:
+            return
+        await self._host.simple_audio_response(pcm, participant)
+
+    def clear(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -1,7 +1,8 @@
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
-from .audio_input_sender import AudioInputHost, AudioInputSender
+from ..llm.llm import AudioLLM
+from .audio_input_sender import AudioInputSender
 
 
 class DirectInput(AudioInputSender):
@@ -11,7 +12,7 @@ class DirectInput(AudioInputSender):
     `super().send(...)` to deliver each chunk through the default path.
     """
 
-    def __init__(self, host: AudioInputHost) -> None:
+    def __init__(self, host: AudioLLM) -> None:
         self._host = host
 
     async def send(self, pcm: PcmData, participant: Participant | None) -> None:

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -16,8 +16,6 @@ class DirectInput(AudioInputSender):
         self._audio_llm = audio_llm
 
     async def send(self, pcm: PcmData, participant: Participant | None) -> None:
-        if not self._audio_llm.connected:
-            return
         if participant is None:
             return
         await self._audio_llm.simple_audio_response(pcm, participant)

--- a/agents-core/vision_agents/core/utils/audio_input_direct.py
+++ b/agents-core/vision_agents/core/utils/audio_input_direct.py
@@ -2,20 +2,22 @@ from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
 from ..llm.llm import AudioLLM
-from .audio_input_sender import AudioInputSender
+from .audio_input_processor import AudioInputProcessor
 
 
-class DirectInput(AudioInputSender):
+class DirectInput(AudioInputProcessor):
     """Forward every PCM chunk straight to the audio LLM's provider.
 
-    Subclasses may override `send` to add buffering/pacing and call
-    `super().send(...)` to deliver each chunk through the default path.
+    Subclasses may override `process_audio` to add buffering/pacing and call
+    `super().process_audio(...)` to deliver each chunk through the default path.
     """
 
     def __init__(self, audio_llm: AudioLLM) -> None:
         self._audio_llm = audio_llm
 
-    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
+    async def process_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None:
         if participant is None:
             return
         await self._audio_llm.simple_audio_response(pcm, participant)

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -1,16 +1,55 @@
 import asyncio
 import logging
+from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
 from .audio_queue import AudioQueue
 
+if TYPE_CHECKING:
+    from ..llm.realtime import Realtime
+
 logger = logging.getLogger(__name__)
 
 AudioInputSender = Callable[[PcmData, Participant | None], Awaitable[None]]
+
+
+class InputAudioStrategy(ABC):
+    """Handler for the input-audio path between Realtime.process_audio and the provider."""
+
+    def __init__(self, realtime: "Realtime") -> None:
+        self._realtime = realtime
+
+    @abstractmethod
+    async def send(self, pcm: PcmData, participant: Participant | None) -> None: ...
+
+    async def _send(self, pcm: PcmData, participant: Participant | None) -> None:
+        rt = self._realtime
+        if not rt.connected:
+            return
+        participant = participant or rt._current_participant
+        if participant is None:
+            return
+        await rt.simple_audio_response(pcm, participant)
+
+    def clear(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class DirectInput(InputAudioStrategy):
+    """Forward every PCM chunk to the provider as it arrives, without buffering."""
+
+    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
+        await self._send(pcm, participant)
+
+
 
 
 @dataclass(slots=True)
@@ -41,17 +80,17 @@ class AudioInputPacingConfig:
             raise ValueError("max_buffer_ms must be at least startup_buffer_ms")
 
 
-class AudioInputPacer:
+class AudioInputPacer(InputAudioStrategy):
     """Buffers input audio and forwards it at a stable wall-clock cadence."""
 
     def __init__(
         self,
+        realtime: "Realtime",
         config: AudioInputPacingConfig,
-        send: AudioInputSender,
         name: str = "audio_input_pacer",
     ) -> None:
+        super().__init__(realtime)
         self.config = config
-        self._send = send
         self._name = name
         self._queue = AudioQueue(buffer_limit_ms=int(config.max_buffer_ms))
         self._task: asyncio.Task[None] | None = None
@@ -62,7 +101,7 @@ class AudioInputPacer:
         self.pauses = 0
         self._generation = 0
 
-    async def push(self, pcm: PcmData, participant: Participant | None) -> None:
+    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
         """Add audio to the pacing buffer, resampling to the configured format."""
         self.start()
         self._participant = participant

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -3,38 +3,43 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Protocol
 
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
 from .audio_queue import AudioQueue
 
-if TYPE_CHECKING:
-    from ..llm.realtime import Realtime
-
 logger = logging.getLogger(__name__)
 
 AudioInputSender = Callable[[PcmData, Participant | None], Awaitable[None]]
 
 
+class AudioInputHost(Protocol):
+    """Structural contract that InputAudioStrategy needs from its host."""
+
+    connected: bool
+
+    async def simple_audio_response(
+        self, pcm: PcmData, participant: Participant
+    ) -> None: ...
+
+
 class InputAudioStrategy(ABC):
     """Handler for the input-audio path between Realtime.process_audio and the provider."""
 
-    def __init__(self, realtime: "Realtime") -> None:
-        self._realtime = realtime
+    def __init__(self, host: AudioInputHost) -> None:
+        self._host = host
 
     @abstractmethod
     async def send(self, pcm: PcmData, participant: Participant | None) -> None: ...
 
     async def _send(self, pcm: PcmData, participant: Participant | None) -> None:
-        rt = self._realtime
-        if not rt.connected:
+        if not self._host.connected:
             return
-        participant = participant or rt._current_participant
         if participant is None:
             return
-        await rt.simple_audio_response(pcm, participant)
+        await self._host.simple_audio_response(pcm, participant)
 
     def clear(self) -> None:
         pass
@@ -85,11 +90,11 @@ class AudioInputPacer(InputAudioStrategy):
 
     def __init__(
         self,
-        realtime: "Realtime",
+        host: AudioInputHost,
         config: AudioInputPacingConfig,
         name: str = "audio_input_pacer",
     ) -> None:
-        super().__init__(realtime)
+        super().__init__(host)
         self.config = config
         self._name = name
         self._queue = AudioQueue(buffer_limit_ms=int(config.max_buffer_ms))

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -121,6 +121,8 @@ class AudioInputPacer(DirectInput):
                 if generation != self._generation:
                     continue
 
+                if not self._audio_llm.connected:
+                    continue
                 try:
                     await super().send(chunk, chunk.participant)
                 except Exception:

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -61,7 +61,9 @@ class AudioInputPacer(DirectInput):
         self.pauses = 0
         self._generation = 0
 
-    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
+    async def process_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None:
         """Add audio to the pacing buffer, resampling to the configured format."""
         self.start()
         self._participant = participant
@@ -124,7 +126,7 @@ class AudioInputPacer(DirectInput):
                 if not self._audio_llm.connected:
                     continue
                 try:
-                    await super().send(chunk, chunk.participant)
+                    await super().process_audio(chunk, chunk.participant)
                 except Exception:
                     logger.exception("%s send failed", self._name)
                     continue

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
-from .audio_input_sender import AudioInputHost
+from ..llm.llm import AudioLLM
 from .audio_input_direct import DirectInput
 from .audio_queue import AudioQueue
 
@@ -45,7 +45,7 @@ class AudioInputPacer(DirectInput):
 
     def __init__(
         self,
-        host: AudioInputHost,
+        host: AudioLLM,
         config: AudioInputPacingConfig,
         name: str = "audio_input_pacer",
     ) -> None:

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -6,7 +6,7 @@ from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
 from ..llm.llm import AudioLLM
-from .audio_input_direct import DirectInput
+from .audio_input_direct import AudioInputDirect
 from .audio_queue import AudioQueue
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class AudioInputPacingConfig:
             raise ValueError("max_buffer_ms must be at least startup_buffer_ms")
 
 
-class AudioInputPacer(DirectInput):
+class AudioInputPacer(AudioInputDirect):
     """Buffers input audio and forwards it at a stable wall-clock cadence."""
 
     def __init__(

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -137,8 +137,6 @@ class AudioInputPacer(DirectInput):
                         self.pauses,
                         self.buffered_ms(),
                     )
-        except asyncio.CancelledError:
-            raise
         except Exception:
             logger.exception("%s stopped unexpectedly", self._name)
 

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -1,60 +1,14 @@
 import asyncio
 import logging
-from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Protocol
 
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
+from .audio_input_sender import AudioInputHost, DirectInput
 from .audio_queue import AudioQueue
 
 logger = logging.getLogger(__name__)
-
-AudioInputSender = Callable[[PcmData, Participant | None], Awaitable[None]]
-
-
-class AudioInputHost(Protocol):
-    """Structural contract that InputAudioStrategy needs from its host."""
-
-    connected: bool
-
-    async def simple_audio_response(
-        self, pcm: PcmData, participant: Participant
-    ) -> None: ...
-
-
-class InputAudioStrategy(ABC):
-    """Handler for the input-audio path between Realtime.process_audio and the provider."""
-
-    def __init__(self, host: AudioInputHost) -> None:
-        self._host = host
-
-    @abstractmethod
-    async def send(self, pcm: PcmData, participant: Participant | None) -> None: ...
-
-    async def _send(self, pcm: PcmData, participant: Participant | None) -> None:
-        if not self._host.connected:
-            return
-        if participant is None:
-            return
-        await self._host.simple_audio_response(pcm, participant)
-
-    def clear(self) -> None:
-        pass
-
-    async def close(self) -> None:
-        pass
-
-
-class DirectInput(InputAudioStrategy):
-    """Forward every PCM chunk to the provider as it arrives, without buffering."""
-
-    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
-        await self._send(pcm, participant)
-
-
 
 
 @dataclass(slots=True)
@@ -85,7 +39,7 @@ class AudioInputPacingConfig:
             raise ValueError("max_buffer_ms must be at least startup_buffer_ms")
 
 
-class AudioInputPacer(InputAudioStrategy):
+class AudioInputPacer(DirectInput):
     """Buffers input audio and forwards it at a stable wall-clock cadence."""
 
     def __init__(
@@ -167,7 +121,7 @@ class AudioInputPacer(InputAudioStrategy):
                     continue
 
                 try:
-                    await self._send(chunk, chunk.participant)
+                    await super().send(chunk, chunk.participant)
                 except Exception:
                     logger.exception("%s send failed", self._name)
                     continue

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
-from .audio_input_sender import AudioInputHost, DirectInput
+from .audio_input_sender import AudioInputHost
+from .audio_input_direct import DirectInput
 from .audio_queue import AudioQueue
 
 logger = logging.getLogger(__name__)

--- a/agents-core/vision_agents/core/utils/audio_input_pacer.py
+++ b/agents-core/vision_agents/core/utils/audio_input_pacer.py
@@ -45,11 +45,11 @@ class AudioInputPacer(DirectInput):
 
     def __init__(
         self,
-        host: AudioLLM,
+        audio_llm: AudioLLM,
         config: AudioInputPacingConfig,
         name: str = "audio_input_pacer",
     ) -> None:
-        super().__init__(host)
+        super().__init__(audio_llm)
         self.config = config
         self._name = name
         self._queue = AudioQueue(buffer_limit_ms=int(config.max_buffer_ms))

--- a/agents-core/vision_agents/core/utils/audio_input_processor.py
+++ b/agents-core/vision_agents/core/utils/audio_input_processor.py
@@ -5,11 +5,13 @@ from getstream.video.rtc.track_util import PcmData
 from ..edge.types import Participant
 
 
-class AudioInputSender(ABC):
+class AudioInputProcessor(ABC):
     """Abstract handler for the input-audio path between Realtime.process_audio and the provider."""
 
     @abstractmethod
-    async def send(self, pcm: PcmData, participant: Participant | None) -> None: ...
+    async def process_audio(
+        self, pcm: PcmData, participant: Participant | None
+    ) -> None: ...
 
     @abstractmethod
     def clear(self) -> None: ...

--- a/agents-core/vision_agents/core/utils/audio_input_sender.py
+++ b/agents-core/vision_agents/core/utils/audio_input_sender.py
@@ -27,27 +27,3 @@ class AudioInputSender(ABC):
 
     @abstractmethod
     async def close(self) -> None: ...
-
-
-class DirectInput(AudioInputSender):
-    """Forward every PCM chunk straight to the host's provider.
-
-    Subclasses may override `send` to add buffering/pacing and call
-    `super().send(...)` to deliver each chunk through the default path.
-    """
-
-    def __init__(self, host: AudioInputHost) -> None:
-        self._host = host
-
-    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
-        if not self._host.connected:
-            return
-        if participant is None:
-            return
-        await self._host.simple_audio_response(pcm, participant)
-
-    def clear(self) -> None:
-        pass
-
-    async def close(self) -> None:
-        pass

--- a/agents-core/vision_agents/core/utils/audio_input_sender.py
+++ b/agents-core/vision_agents/core/utils/audio_input_sender.py
@@ -1,19 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Protocol
 
 from getstream.video.rtc.track_util import PcmData
 
 from ..edge.types import Participant
-
-
-class AudioInputHost(Protocol):
-    """Structural contract that AudioInputSender needs from its host."""
-
-    connected: bool
-
-    async def simple_audio_response(
-        self, pcm: PcmData, participant: Participant
-    ) -> None: ...
 
 
 class AudioInputSender(ABC):

--- a/agents-core/vision_agents/core/utils/audio_input_sender.py
+++ b/agents-core/vision_agents/core/utils/audio_input_sender.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+from getstream.video.rtc.track_util import PcmData
+
+from ..edge.types import Participant
+
+
+class AudioInputHost(Protocol):
+    """Structural contract that AudioInputSender needs from its host."""
+
+    connected: bool
+
+    async def simple_audio_response(
+        self, pcm: PcmData, participant: Participant
+    ) -> None: ...
+
+
+class AudioInputSender(ABC):
+    """Abstract handler for the input-audio path between Realtime.process_audio and the provider."""
+
+    @abstractmethod
+    async def send(self, pcm: PcmData, participant: Participant | None) -> None: ...
+
+    @abstractmethod
+    def clear(self) -> None: ...
+
+    @abstractmethod
+    async def close(self) -> None: ...
+
+
+class DirectInput(AudioInputSender):
+    """Forward every PCM chunk straight to the host's provider.
+
+    Subclasses may override `send` to add buffering/pacing and call
+    `super().send(...)` to deliver each chunk through the default path.
+    """
+
+    def __init__(self, host: AudioInputHost) -> None:
+        self._host = host
+
+    async def send(self, pcm: PcmData, participant: Participant | None) -> None:
+        if not self._host.connected:
+            return
+        if participant is None:
+            return
+        await self._host.simple_audio_response(pcm, participant)
+
+    def clear(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass

--- a/agents-core/vision_agents/core/utils/audio_queue.py
+++ b/agents-core/vision_agents/core/utils/audio_queue.py
@@ -225,6 +225,7 @@ class AudioQueue:
                         sample_rate=item.sample_rate,
                         format=item.format,
                         channels=item.channels,
+                        participant=item.participant,
                     )
                     self._buffer.appendleft(remainder)
                     self._total_samples += len(remainder.samples)

--- a/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
+++ b/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
@@ -824,7 +824,7 @@ class Realtime(realtime.Realtime, Warmable[SileroVADSessionPool]):
         await self.content_end(content_name)
 
     async def close(self):
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
         if not self.connected:
             return
 

--- a/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
+++ b/plugins/aws/vision_agents/plugins/aws/aws_realtime.py
@@ -824,7 +824,7 @@ class Realtime(realtime.Realtime, Warmable[SileroVADSessionPool]):
         await self.content_end(content_name)
 
     async def close(self):
-        await self._close_input_audio()
+        await self._close_audio_input()
         if not self.connected:
             return
 

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -28,7 +28,8 @@ from vision_agents.core.llm.realtime import (
     RealtimeUserSpeechStarted,
     RealtimeUserTranscript,
 )
-from vision_agents.core.utils.audio_input_pacer import AudioInputPacer, DirectInput
+from vision_agents.core.utils.audio_input_pacer import AudioInputPacer
+from vision_agents.core.utils.audio_input_sender import DirectInput
 from vision_agents.plugins.gemini import Realtime
 from vision_agents.plugins.gemini.gemini_realtime import (
     DEFAULT_MODEL,
@@ -77,11 +78,11 @@ class TestGeminiRealtimeInputPacing:
 
         assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
         assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"
-        assert isinstance(default_rt._input_audio, DirectInput)
-        assert isinstance(translate_rt._input_audio, AudioInputPacer)
-        assert translate_rt._input_audio.config.silence_when_empty
-        assert translate_rt._input_audio.config.startup_buffer_ms == 500
-        assert isinstance(translate_opt_out._input_audio, DirectInput)
+        assert type(default_rt._audio_input_sender) is DirectInput
+        assert isinstance(translate_rt._audio_input_sender, AudioInputPacer)
+        assert translate_rt._audio_input_sender.config.silence_when_empty
+        assert translate_rt._audio_input_sender.config.startup_buffer_ms == 500
+        assert type(translate_opt_out._audio_input_sender) is DirectInput
 
 
 class TestGeminiRealtimeProcessEvents:

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -28,6 +28,7 @@ from vision_agents.core.llm.realtime import (
     RealtimeUserSpeechStarted,
     RealtimeUserTranscript,
 )
+from vision_agents.core.utils.audio_input_pacer import AudioInputPacer, DirectInput
 from vision_agents.plugins.gemini import Realtime
 from vision_agents.plugins.gemini.gemini_realtime import (
     DEFAULT_MODEL,
@@ -76,11 +77,11 @@ class TestGeminiRealtimeInputPacing:
 
         assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
         assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"
-        assert default_rt._input_audio_pacer is None
-        assert translate_rt._input_audio_pacer is not None
-        assert translate_rt._input_audio_pacer.config.silence_when_empty
-        assert translate_rt._input_audio_pacer.config.startup_buffer_ms == 500
-        assert translate_opt_out._input_audio_pacer is None
+        assert isinstance(default_rt._input_audio, DirectInput)
+        assert isinstance(translate_rt._input_audio, AudioInputPacer)
+        assert translate_rt._input_audio.config.silence_when_empty
+        assert translate_rt._input_audio.config.startup_buffer_ms == 500
+        assert isinstance(translate_opt_out._input_audio, DirectInput)
 
 
 class TestGeminiRealtimeProcessEvents:

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -29,7 +29,7 @@ from vision_agents.core.llm.realtime import (
     RealtimeUserTranscript,
 )
 from vision_agents.core.utils.audio_input_pacer import AudioInputPacer
-from vision_agents.core.utils.audio_input_direct import DirectInput
+from vision_agents.core.utils.audio_input_direct import AudioInputDirect
 from vision_agents.plugins.gemini import Realtime
 from vision_agents.plugins.gemini.gemini_realtime import (
     DEFAULT_MODEL,
@@ -78,11 +78,11 @@ class TestGeminiRealtimeInputPacing:
 
         assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
         assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"
-        assert type(default_rt._audio_input_processor) is DirectInput
+        assert type(default_rt._audio_input_processor) is AudioInputDirect
         assert isinstance(translate_rt._audio_input_processor, AudioInputPacer)
         assert translate_rt._audio_input_processor.config.silence_when_empty
         assert translate_rt._audio_input_processor.config.startup_buffer_ms == 500
-        assert type(translate_opt_out._audio_input_processor) is DirectInput
+        assert type(translate_opt_out._audio_input_processor) is AudioInputDirect
 
 
 class TestGeminiRealtimeProcessEvents:

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -78,11 +78,11 @@ class TestGeminiRealtimeInputPacing:
 
         assert DEFAULT_MODEL == "gemini-3.1-flash-live-preview"
         assert LIVE_TRANSLATE_MODEL == "gemini-3.5-live-translate-preview"
-        assert type(default_rt._audio_input_sender) is DirectInput
-        assert isinstance(translate_rt._audio_input_sender, AudioInputPacer)
-        assert translate_rt._audio_input_sender.config.silence_when_empty
-        assert translate_rt._audio_input_sender.config.startup_buffer_ms == 500
-        assert type(translate_opt_out._audio_input_sender) is DirectInput
+        assert type(default_rt._audio_input_processor) is DirectInput
+        assert isinstance(translate_rt._audio_input_processor, AudioInputPacer)
+        assert translate_rt._audio_input_processor.config.silence_when_empty
+        assert translate_rt._audio_input_processor.config.startup_buffer_ms == 500
+        assert type(translate_opt_out._audio_input_processor) is DirectInput
 
 
 class TestGeminiRealtimeProcessEvents:

--- a/plugins/gemini/tests/test_gemini_realtime.py
+++ b/plugins/gemini/tests/test_gemini_realtime.py
@@ -29,7 +29,7 @@ from vision_agents.core.llm.realtime import (
     RealtimeUserTranscript,
 )
 from vision_agents.core.utils.audio_input_pacer import AudioInputPacer
-from vision_agents.core.utils.audio_input_sender import DirectInput
+from vision_agents.core.utils.audio_input_direct import DirectInput
 from vision_agents.plugins.gemini import Realtime
 from vision_agents.plugins.gemini.gemini_realtime import (
     DEFAULT_MODEL,

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -367,7 +367,7 @@ class GeminiRealtime(realtime.Realtime):
 
         """
         self._on_disconnected()
-        await self._close_input_audio()
+        await self._close_audio_input()
 
         await self.stop_watching_video_track()
 

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_realtime.py
@@ -367,7 +367,7 @@ class GeminiRealtime(realtime.Realtime):
 
         """
         self._on_disconnected()
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
 
         await self.stop_watching_video_track()
 

--- a/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
@@ -236,7 +236,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(audio)
 
     async def close(self) -> None:
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
         await self._await_pending_tools()
         self._pending_tool_calls.clear()
         await self.rtc.close()

--- a/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
+++ b/plugins/inworld/vision_agents/plugins/inworld/inworld_realtime.py
@@ -236,7 +236,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(audio)
 
     async def close(self) -> None:
-        await self._close_input_audio()
+        await self._close_audio_input()
         await self._await_pending_tools()
         self._pending_tool_calls.clear()
         await self.rtc.close()

--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -191,7 +191,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(pcm)
 
     async def close(self):
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
         await self._await_pending_tools()
         await self.rtc.close()
         self._on_disconnected()

--- a/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
+++ b/plugins/openai/vision_agents/plugins/openai/openai_realtime.py
@@ -191,7 +191,7 @@ class Realtime(realtime.Realtime):
         await self.rtc.send_audio_pcm(pcm)
 
     async def close(self):
-        await self._close_input_audio()
+        await self._close_audio_input()
         await self._await_pending_tools()
         await self.rtc.close()
         self._on_disconnected()

--- a/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
+++ b/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
@@ -126,7 +126,7 @@ class Qwen3Realtime(Realtime):
 
     async def close(self):
         self._on_disconnected()
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
         await self.stop_watching_video_track()
         if self._processing_task is not None:
             self._processing_task.cancel()

--- a/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
+++ b/plugins/qwen/vision_agents/plugins/qwen/qwen_realtime.py
@@ -126,7 +126,7 @@ class Qwen3Realtime(Realtime):
 
     async def close(self):
         self._on_disconnected()
-        await self._close_input_audio()
+        await self._close_audio_input()
         await self.stop_watching_video_track()
         if self._processing_task is not None:
             self._processing_task.cancel()

--- a/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
+++ b/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
@@ -324,7 +324,7 @@ class XAIRealtime(realtime.Realtime):
     async def close(self):
         """Close the connection and clean up resources."""
         self._on_disconnected()
-        await self._close_input_audio()
+        await self._close_audio_input()
 
         await self._await_pending_tools()
 

--- a/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
+++ b/plugins/xai/vision_agents/plugins/xai/xai_realtime.py
@@ -324,7 +324,7 @@ class XAIRealtime(realtime.Realtime):
     async def close(self):
         """Close the connection and clean up resources."""
         self._on_disconnected()
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
 
         await self._await_pending_tools()
 

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -60,7 +60,7 @@ class _RealtimeForPacingTest(Realtime):
         pass
 
     async def close(self) -> None:
-        await self._close_input_audio_pacer()
+        await self._close_input_audio()
         self._on_disconnected()
 
 
@@ -106,58 +106,56 @@ class TestAudioInputPacer(BaseTest):
             await realtime.close()
 
     async def test_virtual_microphone_fills_silence_after_prime(self):
-        sent: list[PcmData] = []
-
-        async def send(pcm: PcmData, participant):
-            sent.append(pcm)
-
+        participant = Participant(original=None, user_id="u", id="u")
+        realtime = _RealtimeForPacingTest()
+        await realtime.connect()
+        realtime._current_participant = participant
         pacer = AudioInputPacer(
+            realtime,
             AudioInputPacingConfig(
                 chunk_ms=5,
                 startup_buffer_ms=10,
                 max_buffer_ms=100,
                 silence_when_empty=True,
             ),
-            send,
         )
 
         try:
-            await pacer.push(_pcm(3, 10), None)
-            await _wait_until(lambda: len(sent) >= 3)
-            assert np.all(sent[0].samples == 3)
-            assert np.all(sent[1].samples == 3)
-            assert any(np.all(chunk.samples == 0) for chunk in sent[2:])
+            await pacer.send(_pcm(3, 10), participant)
+            await _wait_until(lambda: len(realtime.sent) >= 3)
+            assert np.all(realtime.sent[0].samples == 3)
+            assert np.all(realtime.sent[1].samples == 3)
+            assert any(np.all(chunk.samples == 0) for chunk in realtime.sent[2:])
             assert pacer.silence_chunks_sent > 0
 
             pacer.clear()
-            sent_after_clear = len(sent)
+            sent_after_clear = len(realtime.sent)
             await asyncio.sleep(0.02)
-            assert len(sent) == sent_after_clear
+            assert len(realtime.sent) == sent_after_clear
         finally:
             await pacer.close()
 
     async def test_clear_during_chunk_fetch_drops_stale_chunk(self):
-        sent: list[PcmData] = []
-
-        async def send(pcm: PcmData, participant):
-            sent.append(pcm)
-
+        participant = Participant(original=None, user_id="u", id="u")
+        realtime = _RealtimeForPacingTest()
+        await realtime.connect()
+        realtime._current_participant = participant
         pacer = AudioInputPacer(
+            realtime,
             AudioInputPacingConfig(
                 chunk_ms=5,
                 startup_buffer_ms=5,
                 max_buffer_ms=100,
             ),
-            send,
         )
         queue = _ClearingAudioQueue(pacer, _pcm(4, 5))
         pacer._queue = queue
 
         try:
-            pacer.start()
+            await pacer.send(_pcm(4, 5), participant)
             await _wait_until(lambda: queue.was_cleared)
             await asyncio.sleep(0.02)
-            assert sent == []
+            assert realtime.sent == []
             assert pacer.chunks_sent == 0
         finally:
             await pacer.close()

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -60,7 +60,7 @@ class _RealtimeForPacingTest(Realtime):
         pass
 
     async def close(self) -> None:
-        await self._close_input_audio()
+        await self._close_audio_input()
         self._on_disconnected()
 
 

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -109,7 +109,6 @@ class TestAudioInputPacer(BaseTest):
         participant = Participant(original=None, user_id="u", id="u")
         realtime = _RealtimeForPacingTest()
         await realtime.connect()
-        realtime._current_participant = participant
         pacer = AudioInputPacer(
             realtime,
             AudioInputPacingConfig(
@@ -139,7 +138,6 @@ class TestAudioInputPacer(BaseTest):
         participant = Participant(original=None, user_id="u", id="u")
         realtime = _RealtimeForPacingTest()
         await realtime.connect()
-        realtime._current_participant = participant
         pacer = AudioInputPacer(
             realtime,
             AudioInputPacingConfig(

--- a/tests/test_audio_input_pacer.py
+++ b/tests/test_audio_input_pacer.py
@@ -120,7 +120,7 @@ class TestAudioInputPacer(BaseTest):
         )
 
         try:
-            await pacer.send(_pcm(3, 10), participant)
+            await pacer.process_audio(_pcm(3, 10), participant)
             await _wait_until(lambda: len(realtime.sent) >= 3)
             assert np.all(realtime.sent[0].samples == 3)
             assert np.all(realtime.sent[1].samples == 3)
@@ -150,7 +150,7 @@ class TestAudioInputPacer(BaseTest):
         pacer._queue = queue
 
         try:
-            await pacer.send(_pcm(4, 5), participant)
+            await pacer.process_audio(_pcm(4, 5), participant)
             await _wait_until(lambda: queue.was_cleared)
             await asyncio.sleep(0.02)
             assert realtime.sent == []


### PR DESCRIPTION
## Why

Building on #599, the input-audio path can be made significantly clearer:
- `process_audio` had an `if pacer / else` branch and dispatched via a bound-method callback on `Realtime` (`_send_paced_audio`) — bidirectional coupling between the base class and the pacer.
- The `_close_input_audio_pacer` cleanup hook leaked pacer-awareness into every plugin's `close()`.
- `AudioQueue.get_duration` quietly dropped `.participant` when splitting a buffered chunk — masked in production by a fallback to the last-known participant on `Realtime`, but a real data-shape bug.

This branch refactors the input-audio path into a small abstraction with one concrete default and one specialized variant, fixes the queue bug, and removes the protocol/cycle gymnastics that previously hid the coupling.

## Changes

- `fix(audio): preserve participant on AudioQueue split-remainder` — root-cause fix; everything downstream stops needing fallbacks.
- `refactor: introduce InputAudioStrategy for realtime input audio` — turns `process_audio` into a one-liner; replaces the bound-method callback with a polymorphic `send`.
- `refactor: type input audio host via Protocol, drop dead fallback` — strategy stops reaching into private state on `Realtime`.
- `refactor: split input-audio abstraction from pacer implementation` — one file per layer (sender ABC / direct impl / pacer).
- `refactor: extract DirectInput into audio_input_direct module` — keeps the abstraction file purely abstract.
- `refactor: replace AudioInputHost Protocol with AudioLLM base class` — promotes `connected: bool = False` onto `AudioLLM`; sender types its dependency as the concrete base instead of a Protocol.
- `refactor: rename strategy's host parameter to audio_llm` — naming honesty.
- `chore: drop redundant CancelledError re-raise in AudioInputPacer._run` — Python 3.8+ `CancelledError` is a `BaseException`, so the explicit re-raise guarded nothing.

## Validation

- `uv run --no-sync pytest tests/test_audio_input_pacer.py plugins/gemini/tests/test_gemini_realtime.py -m "not integration"` — 29 passed
- `uv run --no-sync ruff check ...` on touched files — clean