### PR TITLE
Fix OpenAI optional tool parameter schemas

### DIFF
--- a/plugins/openai/tests/test_openai_llm.py
+++ b/plugins/openai/tests/test_openai_llm.py
@@ -1,9 +1,12 @@
+import copy
 import os
 
 import pytest
 from dotenv import load_dotenv
 from vision_agents.core.agents.conversation import InMemoryConversation, Message
+from vision_agents.core.llm import FunctionRegistry
 from vision_agents.plugins.openai.openai_llm import OpenAILLM
+from vision_agents.plugins.openai.tool_utils import convert_tools_to_openai_format
 from vision_agents.testing import collect_simple_response
 
 load_dotenv()
@@ -41,6 +44,104 @@ class TestOpenAILLM:
         ]
         messages2 = OpenAILLM._normalize_message(advanced)
         assert messages2[0].original is not None
+
+
+class TestOpenAIToolConversion:
+    """Unit tests for OpenAI function tool schema conversion."""
+
+    def test_required_only_schema_uses_strict_mode(self):
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                    },
+                    "required": ["location"],
+                },
+            }
+        ]
+
+        converted = convert_tools_to_openai_format(tools)
+        parameters = converted[0]["parameters"]
+
+        assert converted[0]["strict"] is True
+        assert parameters["additionalProperties"] is False
+        assert parameters["required"] == ["location"]
+
+    def test_optional_property_schema_disables_strict_mode(self):
+        tools = [
+            {
+                "name": "check_inventory_tool",
+                "description": "Check fake demo inventory for a medication.",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {
+                        "medication_name": {"type": "string"},
+                        "strength": {"type": "string"},
+                    },
+                    "required": ["medication_name"],
+                },
+            }
+        ]
+
+        converted = convert_tools_to_openai_format(tools)
+        parameters = converted[0]["parameters"]
+
+        assert converted[0]["strict"] is False
+        assert parameters["required"] == ["medication_name"]
+        assert "strength" in parameters["properties"]
+
+    def test_realtime_schema_omits_strict_mode(self):
+        tools = [
+            {
+                "name": "get_weather",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            }
+        ]
+
+        converted = convert_tools_to_openai_format(tools, for_realtime=True)
+
+        assert "strict" not in converted[0]
+
+    def test_converter_does_not_mutate_original_schema(self):
+        tools = [
+            {
+                "name": "get_weather",
+                "parameters_schema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            }
+        ]
+        original = copy.deepcopy(tools)
+
+        convert_tools_to_openai_format(tools)
+
+        assert tools == original
+
+    def test_registered_optional_parameter_is_openai_compatible(self):
+        registry = FunctionRegistry()
+
+        @registry.register(description="Check fake demo inventory for a medication.")
+        async def check_inventory_tool(
+            medication_name: str, strength: str | None = None
+        ):
+            return {"medication_name": medication_name, "strength": strength}
+
+        converted = convert_tools_to_openai_format(registry.get_tool_schemas())
+        parameters = converted[0]["parameters"]
+
+        assert converted[0]["strict"] is False
+        assert parameters["required"] == ["medication_name"]
+        assert "strength" in parameters["properties"]
 
 
 @pytest.mark.integration

--- a/plugins/openai/vision_agents/plugins/openai/tool_utils.py
+++ b/plugins/openai/vision_agents/plugins/openai/tool_utils.py
@@ -1,5 +1,6 @@
 """Shared utilities for OpenAI tool/function calling."""
 
+import copy
 import json
 from typing import Any, Dict, List
 
@@ -14,19 +15,20 @@ def convert_tools_to_openai_format(
     Args:
         tools: List of ToolSchema objects from the function registry
         for_realtime: If True, format for Realtime API (no strict field).
-                      If False, format for Responses API (includes strict).
+                      If False, format for Responses API. Strict mode is enabled
+                      only for schemas where every object property is required.
 
     Returns:
         List of tools in OpenAI format
     """
     out = []
     for t in tools or []:
-        params = t.get("parameters_schema") or t.get("parameters") or {}
+        params = copy.deepcopy(t.get("parameters_schema") or t.get("parameters") or {})
         if not isinstance(params, dict):
             params = {}
         params.setdefault("type", "object")
         params.setdefault("properties", {})
-        params.setdefault("additionalProperties", False)
+        _normalize_openai_object_schema(params)
 
         tool_def: Dict[str, Any] = {
             "type": "function",
@@ -35,12 +37,82 @@ def convert_tools_to_openai_format(
             "parameters": params,
         }
 
-        # Responses API supports strict mode, Realtime API does not
+        # Realtime API does not support strict. Responses strict mode rejects
+        # object schemas unless every property is listed in required, so keep
+        # optional/defaulted parameters non-strict to preserve Python defaults.
         if not for_realtime:
-            tool_def["strict"] = True
+            tool_def["strict"] = _is_strict_compatible_schema(params)
 
         out.append(tool_def)
     return out
+
+
+def _normalize_openai_object_schema(schema: Any) -> None:
+    """Normalize object schemas in-place on the OpenAI-specific schema copy."""
+    if not isinstance(schema, dict):
+        return
+
+    schema_type = schema.get("type")
+    is_object = schema_type == "object" or "properties" in schema
+    if is_object:
+        schema.setdefault("properties", {})
+        schema.setdefault("additionalProperties", False)
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for child in properties.values():
+            _normalize_openai_object_schema(child)
+
+    items = schema.get("items")
+    if isinstance(items, dict):
+        _normalize_openai_object_schema(items)
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list):
+            for variant in variants:
+                _normalize_openai_object_schema(variant)
+
+
+def _is_strict_compatible_schema(schema: Any) -> bool:
+    """Return True if every object property is listed as required."""
+    if not isinstance(schema, dict):
+        return True
+
+    schema_type = schema.get("type")
+    is_object = schema_type == "object" or "properties" in schema
+    if is_object:
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            return False
+
+        required = schema.get("required")
+        property_names = set(properties)
+        if property_names:
+            if not isinstance(required, list) or set(required) != property_names:
+                return False
+        elif "required" not in schema:
+            schema["required"] = []
+
+        if schema.get("additionalProperties") is not False:
+            return False
+
+        for child in properties.values():
+            if not _is_strict_compatible_schema(child):
+                return False
+
+    items = schema.get("items")
+    if isinstance(items, dict) and not _is_strict_compatible_schema(items):
+        return False
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list):
+            for variant in variants:
+                if not _is_strict_compatible_schema(variant):
+                    return False
+
+    return True
 
 
 def tool_call_dedup_key(tc: NormalizedToolCallItem) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- avoid invalid OpenAI Responses strict-mode schemas when registered tools have optional/defaulted parameters
- deep-copy and normalize OpenAI tool parameter schemas without mutating the shared registry schema
- keep strict mode for fully required schemas and omit strict mode for OpenAI Realtime
- add regression coverage for optional function parameters like strength: str | None = None

## Tests
- uv run pytest tests/test_function_calling.py plugins/openai/tests/test_openai_llm.py
- uv run ruff check plugins/openai/vision_agents/plugins/openai/tool_utils.py plugins/openai/tests/test_openai_llm.py