### PR TITLE
fix(twelvelabs): wait for asset ready and stamp clip duration for Pegasus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Adds `gemini-3.5-live-translate-preview` as a supported Live Translate model and
 
 ## Bug Fixes
 
+### `twelvelabs` plugin: asset ready wait and clip duration for Pegasus
+
+`PegasusVLM` now polls the TwelveLabs Assets API until an uploaded clip is `ready` before `analyze_stream` — direct uploads return `processing` and must not be analyzed early. Encoded MP4 clips also set PTS/`time_base` so padded buffers report at least 4 seconds of duration (Pegasus's minimum). Uploaded assets are still deleted if ready-wait fails or times out.
+
 ### `openai` plugin: `ChatCompletionsLLM` ignored injected/eager turn text and leaked `<think>` reasoning
 
 `ChatCompletionsLLM.simple_response` rebuilt the request purely from the conversation and ignored its `text` argument unless `participant` was `None`. Because the agent always supplies a participant, injected `agent.simple_response()` instructions produced an empty request (`400 chat content is empty`), and eager turns answered the *previous* transcript. The current `text` is now appended as the trailing user message when the conversation does not already end with it. Additionally, `<think>...</think>` reasoning spans emitted by reasoning models (e.g. MiniMax-M3) are now stripped from streamed deltas and final text so they no longer reach chat or TTS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Adds `gemini-3.5-live-translate-preview` as a supported Live Translate model and
 
 ## Bug Fixes
 
-### `twelvelabs` plugin: asset ready wait and clip duration for Pegasus
+### `twelvelabs` plugin: asset ready wait and clip duration for Pegasus (#610)
 
 `PegasusVLM` now polls the TwelveLabs Assets API until an uploaded clip is `ready` before `analyze_stream` — direct uploads return `processing` and must not be analyzed early. Encoded MP4 clips also set PTS/`time_base` so padded buffers report at least 4 seconds of duration (Pegasus's minimum). Uploaded assets are still deleted if ready-wait fails or times out.
 

--- a/plugins/twelvelabs/tests/test_pegasus_vlm.py
+++ b/plugins/twelvelabs/tests/test_pegasus_vlm.py
@@ -13,6 +13,7 @@ To run only unit tests (no API key needed):
 
 import io
 import os
+from fractions import Fraction
 
 import av
 import numpy as np
@@ -22,10 +23,13 @@ from vision_agents.core.llm.llm import LLMResponseFinal
 from vision_agents.plugins.twelvelabs import PegasusVLM
 
 
-def _solid_frame(width: int, height: int) -> av.VideoFrame:
+def _solid_frame(width: int, height: int, pts: int = 0) -> av.VideoFrame:
     """Build a solid-color RGB frame of the given size."""
     array = np.zeros((height, width, 3), dtype=np.uint8)
-    return av.VideoFrame.from_ndarray(array, format="rgb24")
+    frame = av.VideoFrame.from_ndarray(array, format="rgb24")
+    frame.pts = pts
+    frame.time_base = Fraction(1, 1)
+    return frame
 
 
 class TestPegasusVLM:
@@ -51,7 +55,7 @@ class TestPegasusVLM:
     def test_encode_clip_upscales_to_minimum_and_is_decodable(self):
         """A tiny 64x64 frame must be encoded into a decodable >=360x360 MP4."""
         vlm = PegasusVLM(api_key="x", fps=1.0, clip_seconds=4)
-        frames = [_solid_frame(64, 64), _solid_frame(64, 64)]
+        frames = [_solid_frame(64, 64, pts=0), _solid_frame(64, 64, pts=1)]
 
         clip = vlm._encode_clip(frames)
 
@@ -63,6 +67,9 @@ class TestPegasusVLM:
             assert stream.codec_context.height >= 360
             decoded = [f for f in container.decode(video=0)]
             assert len(decoded) >= 1
+            assert stream.duration is not None
+            duration_s = float(stream.duration * stream.time_base)
+            assert duration_s >= 4.0
         finally:
             container.close()
 

--- a/plugins/twelvelabs/vision_agents/plugins/twelvelabs/pegasus_vlm.py
+++ b/plugins/twelvelabs/vision_agents/plugins/twelvelabs/pegasus_vlm.py
@@ -31,6 +31,9 @@ _MIN_DIMENSION = 360
 # Pegasus rejects clips shorter than this many seconds.
 _MIN_CLIP_SECONDS = 4
 
+_ASSET_POLL_INTERVAL_S = 1.0
+_ASSET_READY_TIMEOUT_S = 120.0
+
 
 class PegasusVLM(llm.VideoLLM):
     """Video understanding VLM backed by TwelveLabs Pegasus.
@@ -161,6 +164,11 @@ class PegasusVLM(llm.VideoLLM):
             asset_id = asset.id
 
             try:
+                # Wait and analyze inside this try so a failed/timed-out ready
+                # poll still cleans up the uploaded asset.
+                if asset.status != "ready":
+                    await self._wait_for_asset_ready(asset_id)
+
                 stream = await asyncio.to_thread(
                     self.client.analyze_stream,
                     model_name=self.model,
@@ -245,6 +253,20 @@ class PegasusVLM(llm.VideoLLM):
     async def _on_frame_received(self, frame: av.VideoFrame) -> None:
         """Buffer the latest sampled frame."""
         self._frame_buffer.append(frame)
+
+    async def _wait_for_asset_ready(self, asset_id: str) -> None:
+        """Poll TwelveLabs until the uploaded asset can be analyzed."""
+        deadline = time.perf_counter() + _ASSET_READY_TIMEOUT_S
+        while time.perf_counter() < deadline:
+            asset = await asyncio.to_thread(self.client.assets.retrieve, asset_id)
+            if asset.status == "ready":
+                return
+            if asset.status == "failed":
+                raise RuntimeError(f"TwelveLabs asset processing failed: id={asset_id}")
+            await asyncio.sleep(_ASSET_POLL_INTERVAL_S)
+        raise TimeoutError(
+            f"TwelveLabs asset not ready after {_ASSET_READY_TIMEOUT_S}s: id={asset_id}"
+        )
 
     def _delete_asset(self, asset_id: str) -> None:
         """Best-effort delete of an uploaded TwelveLabs asset.

--- a/plugins/twelvelabs/vision_agents/plugins/twelvelabs/pegasus_vlm.py
+++ b/plugins/twelvelabs/vision_agents/plugins/twelvelabs/pegasus_vlm.py
@@ -287,8 +287,11 @@ class PegasusVLM(llm.VideoLLM):
             stream.width = width
             stream.height = height
             stream.pix_fmt = "yuv420p"
-            for frame in frames:
+            frame_time_base = Fraction(rate.denominator, rate.numerator)
+            for index, frame in enumerate(frames):
                 reformatted = frame.reformat(width=width, height=height, format="rgb24")
+                reformatted.pts = index
+                reformatted.time_base = frame_time_base
                 for packet in stream.encode(reformatted):
                     container.mux(packet)
             for packet in stream.encode():


### PR DESCRIPTION
## Why

TwelveLabs now processes every Assets upload asynchronously: `assets.create` returns `status=processing`, and the asset must be polled via `assets.retrieve` until `ready` (or `failed`) before analyze. `PegasusVLM` was calling `analyze_stream` immediately after upload, which races the new lifecycle and breaks live analysis.

Separately, Pegasus requires at least 4 seconds of video. We pad short buffers by repeating frames, but without PTS/`time_base` on encoded frames the MP4 may not report a real duration, so validation can still reject the clip as too short.

## Changes

- Poll `assets.retrieve` until the uploaded clip is `ready` before `analyze_stream`, with failed/timeout errors; keep the wait inside the asset-delete `finally` so failed waits do not leak assets
- Stamp PTS and time base when encoding the in-memory MP4 so padded clips meet the 4s minimum
- Unit test asserts encoded clip duration ≥ 4s; changelog entry under Unreleased bug fixes