### PR TITLE
fix(speechify): send Speechify-Caller attribution header

### DIFF
--- a/plugins/speechify/tests/test_tts.py
+++ b/plugins/speechify/tests/test_tts.py
@@ -28,9 +28,12 @@ class TestSpeechifyTTS:
         with pytest.raises(ValueError):
             speechify.TTS()
 
-    def test_sets_caller_attribution_header(self) -> None:
+    async def test_sets_caller_attribution_header(self) -> None:
         tts = speechify.TTS(api_key="fake")
-        assert tts.client._client_wrapper.get_headers()["Speechify-Caller"] == "vision-agents"
+        try:
+            assert tts.client._client_wrapper.get_headers()["Speechify-Caller"] == "vision-agents"
+        finally:
+            await tts.close()
 
     async def test_close_closes_http_client(self) -> None:
         tts = speechify.TTS(api_key="fake")

--- a/plugins/speechify/tests/test_tts.py
+++ b/plugins/speechify/tests/test_tts.py
@@ -31,10 +31,10 @@ class TestSpeechifyTTS:
     async def test_sets_caller_attribution_header(self) -> None:
         tts = speechify.TTS(api_key="fake")
         try:
-             assert (
+            assert (
                 tts.client._client_wrapper.get_headers()["Speechify-Caller"]
-                 == "vision-agents"
-             )
+                == "vision-agents"
+            )
         finally:
             await tts.close()
 

--- a/plugins/speechify/tests/test_tts.py
+++ b/plugins/speechify/tests/test_tts.py
@@ -31,7 +31,10 @@ class TestSpeechifyTTS:
     async def test_sets_caller_attribution_header(self) -> None:
         tts = speechify.TTS(api_key="fake")
         try:
-            assert tts.client._client_wrapper.get_headers()["Speechify-Caller"] == "vision-agents"
+            assert (
+                tts.client._client_wrapper.get_headers()["Speechify-Caller"] 
+                == "vision-agents"
+            )
         finally:
             await tts.close()
 

--- a/plugins/speechify/tests/test_tts.py
+++ b/plugins/speechify/tests/test_tts.py
@@ -28,6 +28,10 @@ class TestSpeechifyTTS:
         with pytest.raises(ValueError):
             speechify.TTS()
 
+    def test_sets_caller_attribution_header(self) -> None:
+        tts = speechify.TTS(api_key="fake")
+        assert tts.client._client_wrapper.get_headers()["Speechify-Caller"] == "vision-agents"
+
     async def test_close_closes_http_client(self) -> None:
         tts = speechify.TTS(api_key="fake")
         httpx_client = tts.client._client_wrapper.httpx_client.httpx_client

--- a/plugins/speechify/tests/test_tts.py
+++ b/plugins/speechify/tests/test_tts.py
@@ -31,10 +31,10 @@ class TestSpeechifyTTS:
     async def test_sets_caller_attribution_header(self) -> None:
         tts = speechify.TTS(api_key="fake")
         try:
-            assert (
-                tts.client._client_wrapper.get_headers()["Speechify-Caller"] 
-                == "vision-agents"
-            )
+             assert (
+                tts.client._client_wrapper.get_headers()["Speechify-Caller"]
+                 == "vision-agents"
+             )
         finally:
             await tts.close()
 

--- a/plugins/speechify/vision_agents/plugins/speechify/tts.py
+++ b/plugins/speechify/vision_agents/plugins/speechify/tts.py
@@ -41,7 +41,12 @@ class TTS(tts.TTS):
             raise ValueError("SPEECHIFY_API_KEY env var or api_key parameter required")
 
         self.client = (
-            client if client is not None else AsyncSpeechify(token=self.api_key)
+            client
+            if client is not None
+            else AsyncSpeechify(
+                token=self.api_key,
+                headers={"Speechify-Caller": "vision-agents"},
+            )
         )
         self.voice_id = voice_id
         self.model = model


### PR DESCRIPTION
Adds headers={'Speechify-Caller': 'vision-agents'} to the AsyncSpeechify client construction in plugins/speechify/vision_agents/plugins/speechify/tts.py, plus a unit test asserting it. Matches the same attribution mechanic we've placed elsewhere.