### PR TITLE
Add metadata to agents

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -843,8 +843,8 @@ class Agent:
             with self.span("edge.authenticate"):
                 self.agent_user.custom = {
                     **self.components_metadata,
-                    **self.agent_user.custom,
                     **{"is_agent": True},
+                    **self.agent_user.custom,
                 }
                 await self.edge.authenticate(self.agent_user)
                 self._agent_user_initialized = True

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -4,7 +4,6 @@ import time
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import (
-    Any,
     AsyncIterator,
     Iterator,
     Optional,
@@ -28,7 +27,7 @@ from ..edge.events import (
     TrackAddedEvent,
     TrackRemovedEvent,
 )
-from ..edge.types import Connection, Participant, TrackType, User
+from ..edge.types import Connection, MetadataValue, Participant, TrackType, User
 from ..events.manager import EventManager
 from ..instructions import Instructions
 from ..llm import events as llm_events
@@ -851,7 +850,7 @@ class Agent:
 
         return None
 
-    def _build_metadata(self) -> dict[str, Any]:
+    def _build_metadata(self) -> dict[str, MetadataValue]:
         """Build the agent-user metadata describing its configured providers."""
         category = (
             "realtime"
@@ -860,7 +859,10 @@ class Agent:
             if _is_video_llm(self.llm)
             else "llm"
         )
-        meta: dict[str, Any] = {"is_agent": True, category: _provider_info(self.llm)}
+        meta: dict[str, MetadataValue] = {
+            "is_agent": True,
+            category: _provider_info(self.llm),
+        }
         if self.stt:
             meta["stt"] = _provider_info(self.stt)
         if self.tts:
@@ -1355,8 +1357,8 @@ def _provider_slug(obj: object) -> str:
     return type(obj).__name__
 
 
-def _provider_info(component: LLM | STT | TTS) -> dict[str, Any]:
-    info: dict[str, Any] = {"provider": _provider_slug(component)}
+def _provider_info(component: LLM | STT | TTS) -> dict[str, MetadataValue]:
+    info: dict[str, MetadataValue] = {"provider": _provider_slug(component)}
     if component.model:
         info["model"] = component.model
     return info

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -4,6 +4,7 @@ import time
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import (
+    Any,
     AsyncIterator,
     Iterator,
     Optional,
@@ -841,10 +842,36 @@ class Agent:
                 return None
 
             with self.span("edge.authenticate"):
+                self.agent_user.custom = {
+                    **self._build_metadata(),
+                    **self.agent_user.custom,
+                }
                 await self.edge.authenticate(self.agent_user)
                 self._agent_user_initialized = True
 
         return None
+
+    def _build_metadata(self) -> dict[str, Any]:
+        """Build the agent-user metadata describing its configured providers."""
+        category = (
+            "realtime"
+            if _is_realtime_llm(self.llm)
+            else "vlm"
+            if _is_video_llm(self.llm)
+            else "llm"
+        )
+        meta: dict[str, Any] = {"is_agent": True, category: _provider_info(self.llm)}
+        if self.stt:
+            meta["stt"] = _provider_info(self.stt)
+        if self.tts:
+            meta["tts"] = _provider_info(self.tts)
+        if self.turn_detection:
+            meta["turn_detection"] = {"provider": _provider_slug(self.turn_detection)}
+        if self.avatar:
+            meta["avatar"] = {"provider": _provider_slug(self.avatar)}
+        if self.processors:
+            meta["processors"] = [_provider_slug(p) for p in self.processors]
+        return meta
 
     async def create_call(self, call_type: str, call_id: str) -> Call:
         """Create a call in the edge provider.
@@ -1319,6 +1346,20 @@ def _is_video_llm(llm: LLM | VideoLLM | AudioLLM) -> TypeGuard[VideoLLM]:
 
 def _is_realtime_llm(llm: LLM | AudioLLM | VideoLLM | Realtime) -> TypeGuard[Realtime]:
     return isinstance(llm, Realtime)
+
+
+def _provider_slug(obj: object) -> str:
+    parts = type(obj).__module__.split(".")
+    if len(parts) >= 3 and parts[0] == "vision_agents" and parts[1] == "plugins":
+        return parts[2]
+    return type(obj).__name__
+
+
+def _provider_info(component: LLM | STT | TTS) -> dict[str, Any]:
+    info: dict[str, Any] = {"provider": _provider_slug(component)}
+    if component.model:
+        info["model"] = component.model
+    return info
 
 
 class _AgentLoggerAdapter(logging.LoggerAdapter):

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -20,6 +20,7 @@ from opentelemetry.trace import Tracer, set_span_in_context
 from opentelemetry.trace.propagation import Context, Span
 
 from ..avatars import Avatar
+from ..base import Component
 from ..edge import Call, EdgeTransport
 from ..edge.events import (
     AudioReceivedEvent,
@@ -49,11 +50,10 @@ from ..tts.tts import TTS
 from ..turn_detection import TurnDetector
 from ..utils.audio_filter import AudioFilter, FirstSpeakerWinsFilter
 from ..utils.audio_queue import AudioQueue
+from ..utils.exceptions import log_exceptions
 from ..utils.logging import (
     CallContextToken,
 )
-from ..base import Component
-from ..utils.exceptions import log_exceptions
 from ..utils.utils import cancel_and_wait
 from ..utils.video_forwarder import VideoForwarder
 from ..utils.video_track import VideoFileTrack
@@ -842,15 +842,17 @@ class Agent:
 
             with self.span("edge.authenticate"):
                 self.agent_user.custom = {
-                    **self._build_metadata(),
+                    **self.components_metadata,
                     **self.agent_user.custom,
+                    **{"is_agent": True},
                 }
                 await self.edge.authenticate(self.agent_user)
                 self._agent_user_initialized = True
 
         return None
 
-    def _build_metadata(self) -> dict[str, MetadataValue]:
+    @property
+    def components_metadata(self) -> dict[str, MetadataValue]:
         """Build the agent-user metadata describing its configured providers."""
         category = (
             "realtime"
@@ -859,20 +861,17 @@ class Agent:
             if _is_video_llm(self.llm)
             else "llm"
         )
-        meta: dict[str, MetadataValue] = {
-            "is_agent": True,
-            category: _provider_info(self.llm),
-        }
+        meta: dict[str, Any] = {category: _component_info(self.llm)}
         if self.stt:
-            meta["stt"] = _provider_info(self.stt)
+            meta["stt"] = _component_info(self.stt)
         if self.tts:
-            meta["tts"] = _provider_info(self.tts)
+            meta["tts"] = _component_info(self.tts)
         if self.turn_detection:
-            meta["turn_detection"] = {"provider": _provider_slug(self.turn_detection)}
+            meta["turn_detection"] = _component_info(self.turn_detection)
         if self.avatar:
-            meta["avatar"] = {"provider": _provider_slug(self.avatar)}
+            meta["avatar"] = _component_info(self.avatar)
         if self.processors:
-            meta["processors"] = [_provider_slug(p) for p in self.processors]
+            meta["processors"] = [_component_info(p) for p in self.processors]
         return meta
 
     async def create_call(self, call_type: str, call_id: str) -> Call:
@@ -1350,17 +1349,31 @@ def _is_realtime_llm(llm: LLM | AudioLLM | VideoLLM | Realtime) -> TypeGuard[Rea
     return isinstance(llm, Realtime)
 
 
-def _provider_slug(obj: object) -> str:
-    parts = type(obj).__module__.split(".")
+def _component_info(component: Component) -> dict[str, Any]:
+    """
+    Get Component's info.
+
+    Args:
+        component: component to look up
+
+    Returns:
+        dict in format {"provider": <plugin name>, "model": <str | None>}
+    """
+    info: dict[str, Any] = {}
+
+    # Parse the package name to use as "provider"
+    parts = type(component).__module__.split(".")
     if len(parts) >= 3 and parts[0] == "vision_agents" and parts[1] == "plugins":
-        return parts[2]
-    return type(obj).__name__
+        provider = parts[2]
+    else:
+        provider = type(component).__name__
 
+    info["provider"] = provider
 
-def _provider_info(component: LLM | STT | TTS) -> dict[str, MetadataValue]:
-    info: dict[str, MetadataValue] = {"provider": _provider_slug(component)}
-    if component.model:
-        info["model"] = component.model
+    model = getattr(component, "model", None)
+    # Return "model" only if it's a string and not some object.
+    if model and isinstance(model, str):
+        info["model"] = model
     return info
 
 

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -861,7 +861,7 @@ class Agent:
             if _is_video_llm(self.llm)
             else "llm"
         )
-        meta: dict[str, Any] = {category: _component_info(self.llm)}
+        meta: dict[str, MetadataValue] = {category: _component_info(self.llm)}
         if self.stt:
             meta["stt"] = _component_info(self.stt)
         if self.tts:
@@ -1349,7 +1349,7 @@ def _is_realtime_llm(llm: LLM | AudioLLM | VideoLLM | Realtime) -> TypeGuard[Rea
     return isinstance(llm, Realtime)
 
 
-def _component_info(component: Component) -> dict[str, Any]:
+def _component_info(component: Component) -> dict[str, MetadataValue]:
     """
     Get Component's info.
 
@@ -1359,7 +1359,7 @@ def _component_info(component: Component) -> dict[str, Any]:
     Returns:
         dict in format {"provider": <plugin name>, "model": <str | None>}
     """
-    info: dict[str, Any] = {}
+    info: dict[str, MetadataValue] = {}
 
     # Parse the package name to use as "provider"
     parts = type(component).__module__.split(".")

--- a/agents-core/vision_agents/core/edge/types.py
+++ b/agents-core/vision_agents/core/edge/types.py
@@ -1,6 +1,6 @@
 import abc
 import enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
@@ -9,6 +9,7 @@ class User:
     id: Optional[str] = ""
     name: Optional[str] = ""
     image: Optional[str] = ""
+    custom: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/agents-core/vision_agents/core/edge/types.py
+++ b/agents-core/vision_agents/core/edge/types.py
@@ -1,7 +1,19 @@
 import abc
 import enum
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Optional, Union
+
+MetadataValue = Union[
+    str,
+    int,
+    float,
+    bool,
+    None,
+    Sequence["MetadataValue"],
+    Mapping[str, "MetadataValue"],
+]
+"""A JSON-compatible value that can be stored in metadata sent to the edge provider."""
 
 
 @dataclass
@@ -9,7 +21,7 @@ class User:
     id: Optional[str] = ""
     name: Optional[str] = ""
     image: Optional[str] = ""
-    custom: dict[str, Any] = field(default_factory=dict)
+    custom: dict[str, MetadataValue] = field(default_factory=dict)
 
 
 @dataclass

--- a/agents-core/vision_agents/core/stt/stt.py
+++ b/agents-core/vision_agents/core/stt/stt.py
@@ -79,6 +79,8 @@ class STT(Component):
     started: bool = False
     turn_detection: bool = False  # if the STT supports turn detection
     eager_turn_detection: bool = False  # if the STT supports turn detection
+    # The model identifier this STT is configured to use.
+    model: str = ""
 
     def __init__(
         self,

--- a/agents-core/vision_agents/core/tts/tts.py
+++ b/agents-core/vision_agents/core/tts/tts.py
@@ -82,6 +82,8 @@ class TTS(Component):
     # utterances. Callers use this to decide whether to feed partial text
     # as it arrives or wait for a full sentence.
     streaming: bool = False
+    # The model identifier this TTS is configured to use.
+    model: str = ""
 
     def __init__(self, provider_name: Optional[str] = None):
         """

--- a/plugins/fish/vision_agents/plugins/fish/tts.py
+++ b/plugins/fish/vision_agents/plugins/fish/tts.py
@@ -3,8 +3,9 @@ import os
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Optional
 
 from fish_audio_sdk import Session, TTSRequest
+from fish_audio_sdk.schemas import Backends
+from getstream.video.rtc.track_util import AudioFormat, PcmData
 from vision_agents.core import tts
-from getstream.video.rtc.track_util import PcmData, AudioFormat
 
 if TYPE_CHECKING:
     from fish_audio_sdk.schemas import Backends
@@ -34,7 +35,7 @@ class TTS(tts.TTS):
         reference_id: Optional[str] = "03397b4c4be74759b72533b663fbd001",
         base_url: Optional[str] = None,
         client: Optional[Session] = None,
-        model: "Backends" = "s2-pro",
+        model: Backends = "s2-pro",
     ):
         """
         Initialize the Fish Audio TTS service.
@@ -68,7 +69,7 @@ class TTS(tts.TTS):
             self.client = Session(api_key)
 
         self.reference_id = reference_id
-        self.model = model
+        self.model: Backends = model
 
     async def stream_audio(
         self, text: str, *_, **kwargs: Any

--- a/plugins/getstream/tests/test_stream_edge_transport.py
+++ b/plugins/getstream/tests/test_stream_edge_transport.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+from getstream.models import QueryUsersPayload, UserRequest
 from getstream.video.rtc import ConnectionManager
 from getstream.video.rtc.pb.stream.video.sfu.models.models_pb2 import Participant
+from vision_agents.core.edge.types import User
 from vision_agents.plugins.getstream.stream_edge_transport import (
     StreamConnection,
     StreamEdge,
@@ -119,3 +121,43 @@ class TestStreamEdge:
         assert stream_edge.client.client.is_closed is True
         assert stream_edge._real_connection is None
         real_connection.leave.assert_called_once()
+
+    @pytest.mark.integration
+    async def test_authenticate_keeps_custom_fields_set_elsewhere(self):
+        """Metadata is merged into the stored user instead of replacing it."""
+        edge = StreamEdge()
+        user_id = f"test-authenticate-{uuid4()}"
+        try:
+            await edge.client.upsert_users(
+                UserRequest(
+                    id=user_id, name="Stored name", custom={"set_elsewhere": "keep me"}
+                )
+            )
+
+            await edge.authenticate(
+                User(id=user_id, name="Agent", custom={"is_agent": True})
+            )
+
+            response = await edge.client.query_users(
+                QueryUsersPayload(filter_conditions={"id": {"$eq": user_id}})
+            )
+            stored = response.data.users[0]
+            assert stored.custom == {"set_elsewhere": "keep me", "is_agent": True}
+            assert stored.name == "Agent"
+        finally:
+            await edge.close()
+
+    @pytest.mark.integration
+    async def test_create_users_creates_users_that_do_not_exist_yet(self):
+        edge = StreamEdge()
+        user_id = f"test-create-users-{uuid4()}"
+        try:
+            created = await edge.create_users(
+                [User(id=user_id, name="New user", custom={"is_agent": False})]
+            )
+
+            assert [u.id for u in created] == [user_id]
+            assert created[0].name == "New user"
+            assert created[0].custom == {"is_agent": False}
+        finally:
+            await edge.close()

--- a/plugins/getstream/tests/test_stream_edge_transport.py
+++ b/plugins/getstream/tests/test_stream_edge_transport.py
@@ -123,7 +123,7 @@ class TestStreamEdge:
         real_connection.leave.assert_called_once()
 
     @pytest.mark.integration
-    async def test_authenticate_keeps_custom_fields_set_elsewhere(self):
+    async def test_authenticate_keeps_custom_fields_set_elsewhere(self) -> None:
         """Metadata is merged into the stored user instead of replacing it."""
         edge = StreamEdge()
         user_id = f"test-authenticate-{uuid4()}"
@@ -148,7 +148,7 @@ class TestStreamEdge:
             await edge.close()
 
     @pytest.mark.integration
-    async def test_create_users_creates_users_that_do_not_exist_yet(self):
+    async def test_create_users_creates_users_that_do_not_exist_yet(self) -> None:
         edge = StreamEdge()
         user_id = f"test-create-users-{uuid4()}"
         try:

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -7,6 +7,12 @@ from typing import TYPE_CHECKING, Optional, cast
 from urllib.parse import urlencode
 
 import aiortc
+from vision_agents.core.agents.agents import tracer
+from vision_agents.core.edge import Call, EdgeTransport, events
+from vision_agents.core.edge.types import Connection, Participant, TrackType, User
+from vision_agents.core.utils import get_vision_agents_version
+from vision_agents.plugins.getstream.stream_conversation import StreamConversation
+
 import getstream.models
 from getstream import AsyncStream
 from getstream.exceptions import StreamApiException
@@ -29,11 +35,6 @@ from getstream.video.rtc.pb.stream.video.sfu.models.models_pb2 import (
 )
 from getstream.video.rtc.track_util import PcmData
 from getstream.video.rtc.tracks import SubscriptionConfig, TrackSubscriptionConfig
-from vision_agents.core.agents.agents import tracer
-from vision_agents.core.edge import Call, EdgeTransport, events
-from vision_agents.core.edge.types import Connection, Participant, TrackType, User
-from vision_agents.core.utils import get_vision_agents_version
-from vision_agents.plugins.getstream.stream_conversation import StreamConversation
 
 from . import sfu_events
 from ._track_resolver import TrackResolver
@@ -343,7 +344,7 @@ class StreamEdge(EdgeTransport[StreamCall]):
         await self._merge_user(user)
         self._agent_user_id = user.id
 
-    async def create_users(self, users: list[User]):
+    async def create_users(self, users: list[User]) -> list[FullUserResponse]:
         """Create multiple users, one API call per user."""
 
         return await asyncio.gather(*(self._merge_user(u) for u in users))

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -337,13 +337,19 @@ class StreamEdge(EdgeTransport[StreamCall]):
             )
 
     async def authenticate(self, user: User) -> None:
-        await self.client.create_user(name=user.name, id=user.id, image=user.image)
+        await self.client.upsert_users(
+            UserRequest(
+                id=user.id, name=user.name, image=user.image, custom=user.custom
+            )
+        )
         self._agent_user_id = user.id
 
     async def create_users(self, users: list[User]):
         """Create multiple users in a single API call."""
 
-        users_map = {u.id: UserRequest(name=u.name, id=u.id) for u in users}
+        users_map = {
+            u.id: UserRequest(name=u.name, id=u.id, custom=u.custom) for u in users
+        }
         response = await self.client.update_users(users_map)
         return [response.data.users[u.id] for u in users]
 

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -9,9 +9,12 @@ from urllib.parse import urlencode
 import aiortc
 import getstream.models
 from getstream import AsyncStream
+from getstream.exceptions import StreamApiException
 from getstream.models import (
     ChannelInput,
     ChannelMemberRequest,
+    FullUserResponse,
+    UpdateUserPartialRequest,
     UserRequest,
 )
 from getstream.video import rtc
@@ -337,21 +340,40 @@ class StreamEdge(EdgeTransport[StreamCall]):
             )
 
     async def authenticate(self, user: User) -> None:
-        await self.client.upsert_users(
-            UserRequest(
-                id=user.id, name=user.name, image=user.image, custom=user.custom
-            )
-        )
+        await self._merge_user(user)
         self._agent_user_id = user.id
 
     async def create_users(self, users: list[User]):
-        """Create multiple users in a single API call."""
+        """Create multiple users, one API call per user."""
 
-        users_map = {
-            u.id: UserRequest(name=u.name, id=u.id, custom=u.custom) for u in users
+        return await asyncio.gather(*(self._merge_user(u) for u in users))
+
+    async def _merge_user(self, user: User) -> FullUserResponse:
+        """Create the user, or merge the locally set fields into an existing one.
+
+        Upserting replaces the stored user, so custom data written by other
+        clients would be lost. A partial update merges instead; it only fails
+        when the user does not exist yet, in which case we create it.
+        """
+        set_fields: dict[str, object] = {
+            key: value
+            for key, value in (("name", user.name), ("image", user.image))
+            if value
         }
-        response = await self.client.update_users(users_map)
-        return [response.data.users[u.id] for u in users]
+        set_fields.update(user.custom)
+        try:
+            response = await self.client.update_users_partial(
+                [UpdateUserPartialRequest(id=user.id, set=set_fields)]
+            )
+        except StreamApiException as e:
+            if e.status_code != 404:
+                raise
+            response = await self.client.upsert_users(
+                UserRequest(
+                    id=user.id, name=user.name, image=user.image, custom=user.custom
+                )
+            )
+        return response.data.users[user.id]
 
     async def create_call(self, call_id: str, **kwargs) -> StreamCall:
         """Shortcut for creating a call/room etc."""

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -440,7 +440,7 @@ class TestAgent:
         custom = agent.agent_user.custom
         assert custom["is_agent"] is False
         assert custom["team"] == "red"
-        assert custom["llm"]["provider"] == "DummyLLM"
+        assert custom["llm"] == {"provider": "DummyLLM"}
 
     async def test_send_metrics_event(self):
         """Test that metrics are sent as custom events."""

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -42,6 +42,8 @@ class DummyTurnDetector(TurnDetector):
 
 
 class DummyTTS(TTS):
+    model = "tts"
+
     async def stream_audio(self, *_, **__):
         return b""
 
@@ -49,6 +51,8 @@ class DummyTTS(TTS):
 
 
 class DummyLLM(LLM, Warmable[bool]):
+    model = "llm"
+
     def __init__(self):
         super(DummyLLM, self).__init__()
         self.warmed_up = False
@@ -653,3 +657,36 @@ class TestAgent:
         )
         assert agent_with.publish_video is True
         assert agent_without.publish_video is False
+
+    async def test_agent_components_metadata_positive(self):
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=DummyEdge(),
+            agent_user=User(name="test"),
+            avatar=DummyAvatar(),
+        )
+        assert agent.components_metadata == {
+            "llm": {"provider": "DummyLLM", "model": "llm"},
+            "tts": {"provider": "DummyTTS", "model": "tts"},
+            "avatar": {"provider": "DummyAvatar"},
+        }
+
+    async def test_agent_components_metadata_model_is_not_str(self):
+        class LLMWithModelObject(DummyLLM):
+            model = object()
+
+        agent = Agent(
+            llm=LLMWithModelObject(),
+            tts=DummyTTS(),
+            edge=DummyEdge(),
+            agent_user=User(name="test"),
+            avatar=DummyAvatar(),
+        )
+        assert agent.components_metadata == {
+            "llm": {
+                "provider": "LLMWithModelObject",
+            },
+            "tts": {"provider": "DummyTTS", "model": "tts"},
+            "avatar": {"provider": "DummyAvatar"},
+        }

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -403,6 +403,45 @@ class TestAgent:
 
         assert edge.last_custom_event == test_data
 
+    async def test_authenticate_attaches_agent_metadata(self):
+        """authenticate() records provider and model metadata on the agent user."""
+        llm = DummyLLM()
+        llm.model = "dummy-llm-model"
+        stt = DummySTT()
+        stt.model = "dummy-stt-model"
+        agent = Agent(
+            llm=llm,
+            stt=stt,
+            tts=DummyTTS(),
+            edge=DummyEdge(),
+            agent_user=User(name="test"),
+        )
+
+        await agent.authenticate()
+
+        custom = agent.agent_user.custom
+        assert custom["is_agent"] is True
+        assert custom["llm"] == {"provider": "DummyLLM", "model": "dummy-llm-model"}
+        assert custom["stt"] == {"provider": "DummySTT", "model": "dummy-stt-model"}
+        # No model set on the TTS -> provider only.
+        assert custom["tts"] == {"provider": "DummyTTS"}
+
+    async def test_authenticate_preserves_user_supplied_custom(self):
+        """User-provided custom keys survive the metadata merge."""
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=DummyEdge(),
+            agent_user=User(name="test", custom={"is_agent": False, "team": "red"}),
+        )
+
+        await agent.authenticate()
+
+        custom = agent.agent_user.custom
+        assert custom["is_agent"] is False
+        assert custom["team"] == "red"
+        assert custom["llm"]["provider"] == "DummyLLM"
+
     async def test_send_metrics_event(self):
         """Test that metrics are sent as custom events."""
         edge = DummyEdge()

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -413,6 +413,10 @@ class TestAgent:
         llm.model = "dummy-llm-model"
         stt = DummySTT()
         stt.model = "dummy-stt-model"
+
+        tts = DummyTTS()
+        tts.model = None
+
         agent = Agent(
             llm=llm,
             stt=stt,

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -420,7 +420,7 @@ class TestAgent:
         agent = Agent(
             llm=llm,
             stt=stt,
-            tts=DummyTTS(),
+            tts=tts,
             edge=DummyEdge(),
             agent_user=User(name="test"),
         )
@@ -448,7 +448,7 @@ class TestAgent:
         custom = agent.agent_user.custom
         assert custom["is_agent"] is False
         assert custom["team"] == "red"
-        assert custom["llm"] == {"provider": "DummyLLM"}
+        assert custom["llm"] == {"provider": "DummyLLM", "model": "llm"}
 
     async def test_send_metrics_event(self):
         """Test that metrics are sent as custom events."""


### PR DESCRIPTION
## Why

- Identifying agents has always been cumbersome (e.g. through a `user-id` but that's very error-prone)
- There's no data on an agent as to what providers they provide

## Changes

I'm adding the necessary metadata to the agent's user data.
That means:
- agent flag
- provider info (stt, tts, realtime, llm + model info if available)

<img width="459" height="498" alt="Screenshot 2026-07-28 at 16 51 40" src="https://github.com/user-attachments/assets/798e8d6f-b9c4-439b-92a7-c6279935b67d" />

