### PR TITLE
feat(telnyx): add Telnyx STT plugin

### DIFF
--- a/plugins/telnyx/README.md
+++ b/plugins/telnyx/README.md
@@ -12,6 +12,7 @@ real-time bidirectional media streaming.
 - **Audio Conversion**: PCMU, PCMA, and L16 RTP payload conversion
 - **WebSocket Management**: Handle Telnyx WebSocket media events
 - **Stream Bridge**: Attach a Telnyx phone participant to a Stream call
+- **STT**: Streaming speech to text over WebSocket
 
 ## Installation
 
@@ -45,6 +46,24 @@ call.telnyx_stream = stream
 # Run the stream until Telnyx sends a stop event
 await stream.run()
 ```
+
+## STT
+
+```python
+from vision_agents.plugins import telnyx
+
+# 8000 matches the PCMU telephony audio that TelnyxMediaStream decodes,
+# so nothing is upsampled on the way to the transcriber.
+stt = telnyx.STT(sample_rate=8000)
+```
+
+Requires `TELNYX_API_KEY` in the environment, or an `api_key` argument.
+
+Audio is resampled to `sample_rate` and sent as raw `linear16` frames. Pick the
+engine with `transcription_engine`; the default is `Telnyx`.
+
+Telnyx does not send VAD signals on this endpoint, so the plugin emits
+transcripts only and leaves turn detection to the agent.
 
 ## Examples
 
@@ -189,5 +208,6 @@ payload = pcm_to_pcmu(pcm)
 ## Dependencies
 
 - vision-agents
+- aiohttp
 - numpy
 - fastapi

--- a/plugins/telnyx/pyproject.toml
+++ b/plugins/telnyx/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy>=1.24.0", # capped at <2.0 via workspace override in root pyproject.toml
     "cryptography>=44.0.0",
     "fastapi>=0.135.1",
+    "aiohttp>=3.13.3",
 ]
 
 [project.urls]

--- a/plugins/telnyx/tests/test_telnyx_stt.py
+++ b/plugins/telnyx/tests/test_telnyx_stt.py
@@ -1,0 +1,164 @@
+"""Tests for the Telnyx STT plugin."""
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+from vision_agents.core.edge.types import Participant
+from vision_agents.core.stt import Transcript
+from vision_agents.plugins.telnyx import STT
+
+load_dotenv()
+
+
+class TestTelnyxSTT:
+    """Unit tests for Telnyx STT configuration and message handling."""
+
+    @pytest.fixture
+    def participant(self) -> Participant:
+        return Participant({}, user_id="test-user", id="test-user")
+
+    async def test_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("TELNYX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="TELNYX_API_KEY"):
+            STT()
+
+    async def test_default_configuration(self):
+        stt = STT(api_key="KEY_test")
+        assert stt.transcription_engine == "Telnyx"
+        assert stt.language == "en"
+        assert stt.sample_rate == 16000
+        assert stt.interim_results is True
+        assert stt.provider_name == "telnyx"
+
+    async def test_invalid_engine_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported Telnyx transcription_engine"):
+            STT(api_key="KEY_test", transcription_engine="NotAnEngine")
+
+    async def test_url_carries_stream_parameters(self):
+        stt = STT(api_key="KEY_test", language="es", sample_rate=8000)
+        url = stt._build_ws_url()
+        assert url.startswith("wss://api.telnyx.com/v2/speech-to-text/transcription?")
+        assert "input_format=linear16" in url
+        assert "sample_rate=8000" in url
+        assert "language=es" in url
+        assert "transcription_engine=Telnyx" in url
+
+    async def test_url_uses_interim_results_not_partial_results(self):
+        on = STT(api_key="KEY_test")._build_ws_url()
+        off = STT(api_key="KEY_test", interim_results=False)._build_ws_url()
+        assert "interim_results=true" in on
+        assert "interim_results=false" in off
+        assert "partial_results" not in on
+
+    async def test_url_omits_model_when_unset(self):
+        assert "model=" not in STT(api_key="KEY_test")._build_ws_url()
+        assert (
+            "model=whisper" in STT(api_key="KEY_test", model="whisper")._build_ws_url()
+        )
+
+    async def test_final_transcript_emitted(self, participant):
+        stt = STT(api_key="KEY_test")
+        stt._current_participant = participant
+
+        stt._handle_message(
+            {"transcript": "hello world", "confidence": 0.9, "is_final": True}
+        )
+        items = await stt.output.collect(timeout=0)
+
+        transcripts = [i for i in items if isinstance(i, Transcript)]
+        assert [t.text for t in transcripts] == ["hello world"]
+        assert transcripts[0].final
+        assert transcripts[0].confidence == 0.9
+        assert transcripts[0].participant == participant
+
+    async def test_interim_transcript_is_not_final(self, participant):
+        stt = STT(api_key="KEY_test")
+        stt._current_participant = participant
+
+        stt._handle_message(
+            {"transcript": "hello", "confidence": None, "is_final": False}
+        )
+        items = await stt.output.collect(timeout=0)
+
+        transcripts = [i for i in items if isinstance(i, Transcript)]
+        assert [t.text for t in transcripts] == ["hello"]
+        assert not transcripts[0].final
+        assert transcripts[0].confidence is None
+
+    async def test_empty_transcript_emits_nothing(self, participant):
+        stt = STT(api_key="KEY_test")
+        stt._current_participant = participant
+
+        stt._handle_message({"transcript": "", "confidence": None, "is_final": True})
+        stt._handle_message({"transcript": "   ", "confidence": None, "is_final": True})
+
+        assert await stt.output.collect(timeout=0) == []
+
+    async def test_error_payload_emits_no_transcript(self, participant):
+        stt = STT(api_key="KEY_test")
+        stt._current_participant = participant
+
+        stt._handle_message(
+            {
+                "errors": [
+                    {
+                        "code": "40001",
+                        "title": "Invalid Parameter",
+                        "detail": "Unsupported input_format 'zzz'.",
+                    }
+                ]
+            }
+        )
+
+        assert await stt.output.collect(timeout=0) == []
+
+
+@pytest.mark.skipif(not os.getenv("TELNYX_API_KEY"), reason="TELNYX_API_KEY not set")
+@pytest.mark.integration
+class TestTelnyxSTTIntegration:
+    """Integration tests against the real Telnyx streaming STT."""
+
+    @pytest.fixture
+    def participant(self) -> Participant:
+        return Participant({}, user_id="test-user", id="test-user")
+
+    @pytest.fixture
+    async def telnyx_stt(self):
+        stt = STT()
+        await stt.start()
+        yield stt
+        await stt.close()
+
+    @pytest.fixture
+    async def telnyx_stt_8khz(self):
+        stt = STT(sample_rate=8000)
+        await stt.start()
+        yield stt
+        await stt.close()
+
+    async def test_transcribe_mia_audio_16khz(
+        self, telnyx_stt, mia_audio_16khz, participant
+    ):
+        await telnyx_stt.process_audio(mia_audio_16khz, participant=participant)
+
+        items = await telnyx_stt.output.collect(timeout=15.0)
+
+        transcripts = [i for i in items if isinstance(i, Transcript)]
+        assert transcripts, "No Transcript emitted by Telnyx STT"
+        finals = [t for t in transcripts if t.final]
+        assert finals, "No final Transcript emitted by Telnyx STT"
+        assert "forgotten treasures" in " ".join(t.text for t in finals).lower()
+        assert transcripts[0].participant == participant
+
+    async def test_transcribe_at_telephony_sample_rate(
+        self, telnyx_stt_8khz, mia_audio_16khz, participant
+    ):
+        """8 kHz is what TelnyxMediaStream produces from PCMU telephony audio."""
+        await telnyx_stt_8khz.process_audio(mia_audio_16khz, participant=participant)
+
+        items = await telnyx_stt_8khz.output.collect(timeout=15.0)
+
+        finals = [i for i in items if isinstance(i, Transcript) and i.final]
+        assert finals, "No final Transcript emitted at 8kHz"
+        assert "forgotten treasures" in " ".join(t.text for t in finals).lower()

--- a/plugins/telnyx/tests/test_telnyx_stt.py
+++ b/plugins/telnyx/tests/test_telnyx_stt.py
@@ -2,8 +2,11 @@
 
 import os
 
+import aiohttp
+import numpy as np
 import pytest
 from dotenv import load_dotenv
+from getstream.video.rtc.track_util import PcmData
 from vision_agents.core.edge.types import Participant
 from vision_agents.core.stt import Transcript
 from vision_agents.plugins.telnyx import STT
@@ -94,6 +97,33 @@ class TestTelnyxSTT:
         stt._handle_message({"transcript": "   ", "confidence": None, "is_final": True})
 
         assert await stt.output.collect(timeout=0) == []
+
+    async def test_send_failure_does_not_propagate(self, participant):
+        stt = STT(api_key="KEY_test")
+
+        class FailingWS:
+            closed = False
+
+            async def send_bytes(self, data: bytes) -> None:
+                raise aiohttp.ClientError("connection reset")
+
+        stt._ws = FailingWS()
+        stt._connection_ready.set()
+
+        pcm = PcmData(
+            samples=np.zeros(160, dtype=np.int16), sample_rate=16000, format="s16"
+        )
+        await stt.process_audio(pcm, participant=participant)
+
+    async def test_integer_confidence_is_kept(self, participant):
+        stt = STT(api_key="KEY_test")
+        stt._current_participant = participant
+
+        stt._handle_message({"transcript": "hello", "confidence": 1, "is_final": True})
+        items = await stt.output.collect(timeout=0)
+
+        transcripts = [i for i in items if isinstance(i, Transcript)]
+        assert transcripts[0].confidence == 1.0
 
     async def test_error_payload_emits_no_transcript(self, participant):
         stt = STT(api_key="KEY_test")

--- a/plugins/telnyx/vision_agents/plugins/telnyx/__init__.py
+++ b/plugins/telnyx/vision_agents/plugins/telnyx/__init__.py
@@ -14,6 +14,7 @@ from .audio import (
 )
 from .call_registry import TelnyxCall, TelnyxCallRegistry
 from .media_stream import TelnyxMediaFormat, TelnyxMediaStream, attach_phone_to_call
+from .stt import STT
 
 CallRegistry = TelnyxCallRegistry
 MediaStream = TelnyxMediaStream
@@ -21,6 +22,7 @@ MediaStream = TelnyxMediaStream
 __all__ = [
     "CallRegistry",
     "MediaStream",
+    "STT",
     "TELNYX_DEFAULT_SAMPLE_RATE",
     "TELNYX_L16_SAMPLE_RATE",
     "TelnyxCall",

--- a/plugins/telnyx/vision_agents/plugins/telnyx/stt.py
+++ b/plugins/telnyx/vision_agents/plugins/telnyx/stt.py
@@ -118,10 +118,15 @@ class STT(stt.STT):
         # that do have to suppress it, because the Telnyx edge rejects a
         # WebSocket handshake that carries one.
         self._session = aiohttp.ClientSession()
-        self._ws = await self._session.ws_connect(
-            self._build_ws_url(),
-            headers={"Authorization": f"Bearer {self._api_key}"},
-        )
+        try:
+            self._ws = await self._session.ws_connect(
+                self._build_ws_url(),
+                headers={"Authorization": f"Bearer {self._api_key}"},
+            )
+        except BaseException:
+            await self._session.close()
+            self._session = None
+            raise
 
         self._receive_task = asyncio.create_task(self._receive_loop())
         self._connection_ready.set()
@@ -149,31 +154,39 @@ class STT(stt.STT):
         if self._audio_start_time is None:
             self._audio_start_time = time.perf_counter()
 
-        await self._ws.send_bytes(resampled.samples.tobytes())
+        try:
+            await self._ws.send_bytes(resampled.samples.tobytes())
+        except (aiohttp.ClientError, ConnectionError) as exc:
+            self._emit_error_event(exc, context="telnyx_send_audio")
 
     async def close(self) -> None:
         """Close the WebSocket and clean up."""
         await super().close()
 
-        if self._ws is not None and not self._ws.closed:
-            await self._ws.close()
-        self._ws = None
-
-        if self._receive_task is not None:
-            self._receive_task.cancel()
+        try:
+            if self._ws is not None and not self._ws.closed:
+                await self._ws.close()
+        finally:
+            self._ws = None
             try:
-                await self._receive_task
-            except asyncio.CancelledError:
-                pass
-            self._receive_task = None
-
-        if self._session is not None and not self._session.closed:
-            await self._session.close()
-        self._session = None
-
-        self._connection_ready.clear()
-        self._on_disconnected()
-        self._audio_start_time = None
+                if self._receive_task is not None:
+                    self._receive_task.cancel()
+                    try:
+                        await self._receive_task
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        logger.exception("Telnyx STT receive task failed on close")
+            finally:
+                self._receive_task = None
+                try:
+                    if self._session is not None and not self._session.closed:
+                        await self._session.close()
+                finally:
+                    self._session = None
+                    self._connection_ready.clear()
+                    self._on_disconnected()
+                    self._audio_start_time = None
 
     def _build_ws_url(self) -> str:
         params: dict[str, str] = {
@@ -198,6 +211,9 @@ class STT(stt.STT):
                         parsed = json.loads(msg.data)
                     except json.JSONDecodeError:
                         logger.warning("Telnyx STT sent non-JSON text: %s", msg.data)
+                        continue
+                    if not isinstance(parsed, dict):
+                        logger.warning("Telnyx STT sent unexpected payload: %r", parsed)
                         continue
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.debug("Telnyx STT message: %s", parsed)
@@ -254,10 +270,12 @@ class STT(stt.STT):
             processing_time_ms = (time.perf_counter() - self._audio_start_time) * 1000
 
         confidence = data.get("confidence")
+        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+            confidence = None
         is_final = bool(data.get("is_final", True))
 
         response = TranscriptResponse(
-            confidence=confidence if isinstance(confidence, float) else None,
+            confidence=float(confidence) if confidence is not None else None,
             language=self.language,
             model_name=self.model or self.transcription_engine,
             processing_time_ms=processing_time_ms,

--- a/plugins/telnyx/vision_agents/plugins/telnyx/stt.py
+++ b/plugins/telnyx/vision_agents/plugins/telnyx/stt.py
@@ -1,0 +1,270 @@
+"""Telnyx Speech-to-Text via WebSocket streaming.
+
+Docs: https://developers.telnyx.com/api/call-control/speech-to-text
+
+Audio is sent as raw binary frames in the encoding named by ``input_format``.
+The default is ``linear16``, for which Telnyx requires an explicit
+``sample_rate``. Transcripts come back as
+``{"transcript": str, "confidence": float | None, "is_final": bool}``.
+
+The query parameter for partial transcripts is ``interim_results``.
+``partial_results`` is accepted by the endpoint but ignored, which silently
+yields finals only.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Optional
+from urllib.parse import urlencode
+
+import aiohttp
+from getstream.video.rtc.track_util import PcmData
+from vision_agents.core import stt
+from vision_agents.core.edge.types import Participant
+from vision_agents.core.stt import TranscriptResponse
+
+logger = logging.getLogger(__name__)
+
+WS_STT_URL = "wss://api.telnyx.com/v2/speech-to-text/transcription"
+
+SUPPORTED_ENGINES = {
+    "AssemblyAI",
+    "Azure",
+    "Deepgram",
+    "Google",
+    "Humain",
+    "Parakeet",
+    "Reson8",
+    "Soniox",
+    "Speechmatics",
+    "Telnyx",
+    "xAI",
+}
+
+
+class STT(stt.STT):
+    """Telnyx streaming Speech-to-Text.
+
+    Uses aiohttp for a fully async WebSocket connection to the Telnyx streaming
+    endpoint. Audio is resampled to the configured rate and sent as raw
+    ``linear16`` binary frames.
+
+    Telnyx does not send VAD signals on this endpoint, so turn detection is
+    left to the agent's own turn detection.
+
+    Examples:
+
+        from vision_agents.plugins import telnyx
+        stt = telnyx.STT(sample_rate=8000)
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        transcription_engine: str = "Telnyx",
+        language: str = "en",
+        sample_rate: int = 16000,
+        interim_results: bool = True,
+        model: Optional[str] = None,
+    ) -> None:
+        """Initialize Telnyx STT.
+
+        Args:
+            api_key: Telnyx API key. Falls back to the ``TELNYX_API_KEY`` env var.
+            transcription_engine: Engine to transcribe with. Defaults to
+                ``Telnyx``.
+            language: Language code, for example ``en``.
+            sample_rate: Rate in Hz that audio is resampled to before being
+                sent. Use 8000 to pass telephony audio from
+                :class:`TelnyxMediaStream` through without upsampling.
+            interim_results: Emit partial transcripts as they are refined.
+            model: Optional engine-specific model id.
+        """
+        super().__init__(provider_name="telnyx")
+
+        if transcription_engine not in SUPPORTED_ENGINES:
+            raise ValueError(
+                f"Unsupported Telnyx transcription_engine '{transcription_engine}'. "
+                f"Expected one of: {sorted(SUPPORTED_ENGINES)}"
+            )
+
+        self._api_key = api_key or os.environ.get("TELNYX_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "TELNYX_API_KEY env var or api_key parameter required for Telnyx STT"
+            )
+
+        self.transcription_engine = transcription_engine
+        self.language = language
+        self.sample_rate = sample_rate
+        self.interim_results = interim_results
+        self.model = model
+
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._receive_task: Optional[asyncio.Task[None]] = None
+        self._connection_ready = asyncio.Event()
+        self._current_participant: Optional[Participant] = None
+        self._audio_start_time: Optional[float] = None
+
+    async def start(self) -> None:
+        """Open the Telnyx WebSocket and start the receive loop."""
+        await super().start()
+
+        # aiohttp does not attach an Origin header to the handshake. Clients
+        # that do have to suppress it, because the Telnyx edge rejects a
+        # WebSocket handshake that carries one.
+        self._session = aiohttp.ClientSession()
+        self._ws = await self._session.ws_connect(
+            self._build_ws_url(),
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+
+        self._receive_task = asyncio.create_task(self._receive_loop())
+        self._connection_ready.set()
+        self._on_connected()
+
+    async def process_audio(
+        self,
+        pcm_data: PcmData,
+        participant: Participant,
+    ) -> None:
+        """Resample a PCM chunk to the configured rate and send it to Telnyx."""
+        if self.closed:
+            logger.warning("Telnyx STT is closed, ignoring audio")
+            return
+
+        await self._connection_ready.wait()
+
+        if self._ws is None or self._ws.closed:
+            logger.warning("Telnyx STT WebSocket not open, dropping audio")
+            return
+
+        resampled = pcm_data.resample(self.sample_rate, 1)
+
+        self._current_participant = participant
+        if self._audio_start_time is None:
+            self._audio_start_time = time.perf_counter()
+
+        await self._ws.send_bytes(resampled.samples.tobytes())
+
+    async def close(self) -> None:
+        """Close the WebSocket and clean up."""
+        await super().close()
+
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+        if self._receive_task is not None:
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except asyncio.CancelledError:
+                pass
+            self._receive_task = None
+
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+        self._connection_ready.clear()
+        self._on_disconnected()
+        self._audio_start_time = None
+
+    def _build_ws_url(self) -> str:
+        params: dict[str, str] = {
+            "transcription_engine": self.transcription_engine,
+            "input_format": "linear16",
+            "sample_rate": str(self.sample_rate),
+            "language": self.language,
+            "interim_results": "true" if self.interim_results else "false",
+        }
+        if self.model is not None:
+            params["model"] = self.model
+        return f"{WS_STT_URL}?{urlencode(params)}"
+
+    async def _receive_loop(self) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        parsed = json.loads(msg.data)
+                    except json.JSONDecodeError:
+                        logger.warning("Telnyx STT sent non-JSON text: %s", msg.data)
+                        continue
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug("Telnyx STT message: %s", parsed)
+                    self._handle_message(parsed)
+                elif msg.type in (
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.ERROR,
+                ):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except aiohttp.ClientError:
+            logger.exception("Telnyx STT receive loop error")
+
+        if not self.closed:
+            self._emit_error_event(
+                ConnectionError("Telnyx STT WebSocket closed unexpectedly"),
+                context="telnyx_ws_closed",
+            )
+
+    def _handle_message(self, data: dict[str, object]) -> None:
+        """Dispatch a parsed Telnyx WebSocket message.
+
+        Transcripts arrive as
+        ``{"transcript": str, "confidence": float | None, "is_final": bool}``.
+        Parameter rejections arrive as ``{"errors": [{"detail": ...}, ...]}``
+        and are followed by the server closing the connection.
+        """
+        errors = data.get("errors")
+        if isinstance(errors, list) and errors:
+            details = "; ".join(
+                str(err.get("detail") or err.get("title"))
+                for err in errors
+                if isinstance(err, dict)
+            )
+            self._emit_error_event(
+                RuntimeError(details or "Telnyx STT error"),
+                context="telnyx_streaming",
+            )
+            return
+
+        text = data.get("transcript")
+        if not isinstance(text, str) or not text.strip():
+            return
+
+        participant = self._current_participant
+        if participant is None:
+            logger.warning("Telnyx transcript received but no participant set")
+            return
+
+        processing_time_ms: Optional[float] = None
+        if self._audio_start_time is not None:
+            processing_time_ms = (time.perf_counter() - self._audio_start_time) * 1000
+
+        confidence = data.get("confidence")
+        is_final = bool(data.get("is_final", True))
+
+        response = TranscriptResponse(
+            confidence=confidence if isinstance(confidence, float) else None,
+            language=self.language,
+            model_name=self.model or self.transcription_engine,
+            processing_time_ms=processing_time_ms,
+        )
+
+        if is_final:
+            self._audio_start_time = None
+            self._emit_transcript_event(text, participant, response)
+        else:
+            self._emit_transcript_event(text, participant, response, mode="replacement")

--- a/uv.lock
+++ b/uv.lock
@@ -7535,6 +7535,7 @@ dev = [
 name = "vision-agents-plugins-telnyx"
 source = { editable = "plugins/telnyx" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "numpy" },
@@ -7549,6 +7550,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "numpy", specifier = ">=1.24.0" },


### PR DESCRIPTION
Adds streaming Telnyx STT to `plugins/telnyx/`, which today only contains the
media streaming transport from #594. The pattern precedent is `plugins/sarvam/`,
which keeps `llm.py`, `stt.py`, and `tts.py` in one vendor plugin. LLM and TTS
are separate PRs so each lands independently.

## What it adds

- `plugins/telnyx/vision_agents/plugins/telnyx/stt.py`
- `STT` export in the plugin `__init__.py`
- `aiohttp` dependency in the plugin `pyproject.toml`
- Unit and integration tests in `plugins/telnyx/tests/test_telnyx_stt.py`
- README section

## Sample rate and the existing transport

`TelnyxMediaStream` decodes PCMU telephony audio to 8 kHz `PcmData` today. The
plugin takes a `sample_rate` argument, resamples each chunk to it, and sends
raw `linear16` frames, so a phone agent can run `telnyx.STT(sample_rate=8000)`
and avoid an upsample to 16 kHz that adds nothing back.

The default is 16000, which suits non telephony sources. Telnyx requires an
explicit `sample_rate` for raw encodings, so there is no negotiate-from-stream
path on the wire. If you would rather the plugin read the rate off an attached
`TelnyxMediaStream` instead of taking it as an argument, say so and I will
change it, but that couples STT construction to a live call and the current
shape matches how the other STT plugins are configured.

## Turn detection

`turn_detection` is left at the base default of `False`. This endpoint sends
only `{"transcript", "confidence", "is_final"}` and no VAD signals, so unlike
sarvam there is nothing to derive `TurnStarted` and `TurnEnded` from, and the
agent's own turn detection handles it. Flagging in case a maintainer knows of a
VAD parameter on this endpoint that is not surfaced in the errors the server
returns for unknown parameters.

## Protocol note

The query parameter for partial transcripts is `interim_results`.
`partial_results` is accepted by the endpoint but ignored, which silently gives
finals only. There is a unit test pinning this so it does not regress.

The Telnyx edge rejects a WebSocket handshake carrying an `Origin` header.
aiohttp does not send one, so no workaround is needed here, but there is a
comment at the connect site because it is not obvious.

## Testing

Verified against the live Telnyx API, not from docs alone. Supported values for
`transcription_engine` and `input_format` were read off the errors the server
returns for unknown values rather than guessed.

- `uv run ruff check .` and `ruff format --check .` pass
- `uv run dev.py mypy` and `dev.py mypy-plugins` pass
- `uv run dev.py validate-extras` passes
- `uv run pytest -m "not integration" plugins/telnyx/tests/` passes, 41 tests
- `uv run pytest -m integration plugins/telnyx/tests/test_telnyx_stt.py` passes
  with a real `TELNYX_API_KEY`, 2 tests transcribing the shared `mia.mp3`
  fixture, one at 16 kHz and one at the 8 kHz telephony rate

`uv.lock` changes by two lines, for the new dependency.



## Relation to the other two Telnyx PRs

This is one of three independent PRs, each branched off `main`, not stacked:
#620 LLM, #621 TTS, #622 STT. Each touches the plugin `__init__.py`,
`pyproject.toml`, `README.md`, and two lines of `uv.lock`, so whichever lands
first leaves the other two with small conflicts in those four files. Happy to
rebase on request, or to fold all three into one PR if you would rather review
them together.