### PR TITLE
fix(nvidia): default VLM to llama-3.2-11b-vision-instruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The Anam avatar plugin now depends on `anam>=0.6.0,<0.7` (was `>=0.3.0,<0.4`). S
 
 ## Bug Fixes
 
+### `nvidia` plugin: default VLM model is now `meta/llama-3.2-11b-vision-instruct`
+
+`nvidia/cosmos-reason2-8b` is no longer available on the NVIDIA Chat Completions API for typical API Catalog keys. The plugin default, README, and example now use `meta/llama-3.2-11b-vision-instruct`.
+
 ### `twelvelabs` plugin: asset ready wait and clip duration for Pegasus (#610)
 
 `PegasusVLM` now polls the TwelveLabs Assets API until an uploaded clip is `ready` before `analyze_stream` — direct uploads return `processing` and must not be analyzed early. Encoded MP4 clips also set PTS/`time_base` so padded buffers report at least 4 seconds of duration (Pegasus's minimum). Uploaded assets are still deleted if ready-wait fails or times out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The Anam avatar plugin now depends on `anam>=0.6.0,<0.7` (was `>=0.3.0,<0.4`). S
 
 ## Bug Fixes
 
-### `nvidia` plugin: default VLM model is now `meta/llama-3.2-11b-vision-instruct`
+### `nvidia` plugin: default VLM model is now `meta/llama-3.2-11b-vision-instruct` (#625)
 
 `nvidia/cosmos-reason2-8b` is no longer available on the NVIDIA Chat Completions API for typical API Catalog keys. The plugin default, README, and example now use `meta/llama-3.2-11b-vision-instruct`.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ agent = Agent(
 
 **TTS:** [ElevenLabs](https://visionagents.ai/integrations/elevenlabs) · [Cartesia](https://visionagents.ai/integrations/cartesia) · [Deepgram](https://visionagents.ai/integrations/deepgram) · [AWS Polly](https://visionagents.ai/integrations/aws-polly) · [Pocket](https://visionagents.ai/integrations/pocket) · [Kokoro](https://visionagents.ai/integrations/kokoro) · [Inworld](https://visionagents.ai/integrations/inworld) · [Fish Audio](https://visionagents.ai/integrations/fish)
 
-**Vision:** [Ultralytics](https://visionagents.ai/integrations/ultralytics) · [Roboflow](https://visionagents.ai/integrations/roboflow) · [Moondream](https://visionagents.ai/integrations/moondream) · [TwelveLabs](https://github.com/GetStream/Vision-Agents/tree/main/plugins/twelvelabs) · [NVIDIA Cosmos](https://visionagents.ai/integrations/nvidia) · [Decart](https://visionagents.ai/integrations/decart)
+**Vision:** [Ultralytics](https://visionagents.ai/integrations/ultralytics) · [Roboflow](https://visionagents.ai/integrations/roboflow) · [Moondream](https://visionagents.ai/integrations/moondream) · [TwelveLabs](https://github.com/GetStream/Vision-Agents/tree/main/plugins/twelvelabs) · [NVIDIA](https://visionagents.ai/integrations/nvidia) · [Decart](https://visionagents.ai/integrations/decart)
 
 **Avatars:** [LemonSlice](https://visionagents.ai/integrations/lemonslice)
 

--- a/plugins/nvidia/README.md
+++ b/plugins/nvidia/README.md
@@ -33,7 +33,7 @@ export NVIDIA_API_KEY=your_nvidia_api_key
 from vision_agents.plugins import nvidia
 
 vlm = nvidia.VLM(
-    model="nvidia/cosmos-reason2-8b",
+    model="meta/llama-3.2-11b-vision-instruct",
     fps=1,
     frame_buffer_seconds=10,
 )
@@ -49,7 +49,7 @@ print(response.text)
 from vision_agents.plugins import nvidia
 
 vlm = nvidia.VLM(
-    model="nvidia/cosmos-reason2-8b",
+    model="meta/llama-3.2-11b-vision-instruct",
     api_key="your-api-key",
     fps=2,
     frame_buffer_seconds=15,
@@ -65,7 +65,7 @@ vlm = nvidia.VLM(
 
 | Parameter              | Description                                        | Default                      | Type          |
 |------------------------|----------------------------------------------------|------------------------------|---------------|
-| `model`                | NVIDIA model ID                                    | `"nvidia/cosmos-reason2-8b"` | str           |
+| `model`                | NVIDIA model ID                                    | `"meta/llama-3.2-11b-vision-instruct"` | str           |
 | `api_key`              | NVIDIA API token (or use `NVIDIA_API_KEY` env var) | `None`                       | Optional[str] |
 | `fps`                  | Frames per second to buffer                        | `1`                          | int           |
 | `frame_buffer_seconds` | Number of seconds to buffer                        | `10`                         | int           |

--- a/plugins/nvidia/example/README.md
+++ b/plugins/nvidia/example/README.md
@@ -61,7 +61,7 @@ You can customize the VLM settings in `main.py`:
 
 ```python
 llm = nvidia.VLM(
-    model="nvidia/cosmos-reason2-8b",
+    model="meta/llama-3.2-11b-vision-instruct",
     fps=1,  # Frames per second to buffer
     frame_buffer_seconds=10,  # Seconds of video to buffer
     frame_width=800,  # Frame width

--- a/plugins/nvidia/example/main.py
+++ b/plugins/nvidia/example/main.py
@@ -29,7 +29,7 @@ load_dotenv()
 async def create_agent(**kwargs) -> Agent:
     """Create the agent with NVIDIA VLM."""
     llm = nvidia.VLM(
-        model="nvidia/cosmos-reason2-8b",
+        model="meta/llama-3.2-11b-vision-instruct",
         fps=1,
         frame_buffer_seconds=10,
     )

--- a/plugins/nvidia/tests/test_nvidia_vlm.py
+++ b/plugins/nvidia/tests/test_nvidia_vlm.py
@@ -45,7 +45,7 @@ async def vlm() -> VLM:
     if not api_key:
         pytest.skip("NVIDIA_API_KEY not set")
 
-    vlm_instance = VLM(model="meta/llama-3.2-11b-vision-instruct")
+    vlm_instance = VLM()
     vlm_instance.set_conversation(InMemoryConversation("be friendly", []))
     try:
         yield vlm_instance

--- a/plugins/nvidia/vision_agents/plugins/nvidia/nvidia_vlm.py
+++ b/plugins/nvidia/vision_agents/plugins/nvidia/nvidia_vlm.py
@@ -50,13 +50,13 @@ class NvidiaVLM(VideoLLM):
     Examples:
 
         from vision_agents.plugins import nvidia
-        vlm = nvidia.VLM(model="nvidia/cosmos-reason2-8b")
+        vlm = nvidia.VLM(model="meta/llama-3.2-11b-vision-instruct")
 
     """
 
     def __init__(
         self,
-        model: str = "nvidia/cosmos-reason2-8b",
+        model: str = "meta/llama-3.2-11b-vision-instruct",
         api_key: Optional[str] = None,
         fps: int = 1,
         frame_buffer_seconds: int = 10,
@@ -72,7 +72,7 @@ class NvidiaVLM(VideoLLM):
         Initialize the NvidiaVLM class.
 
         Args:
-            model: The NVIDIA model ID to use. Defaults to "nvidia/cosmos-reason2-8b".
+            model: The NVIDIA model ID to use. Defaults to "meta/llama-3.2-11b-vision-instruct".
             api_key: NVIDIA API token. Defaults to NVIDIA_API_KEY environment variable.
             fps: Number of video frames per second to handle.
             frame_buffer_seconds: Number of seconds to buffer for the model's input.


### PR DESCRIPTION
## Why
`nvidia/cosmos-reason2-8b` returns 404 on the NVIDIA Chat Completions API for typical API Catalog keys, so the plugin default and examples no longer work out of the box. `meta/llama-3.2-11b-vision-instruct` is available on `/v1/chat/completions` and passes the nvidia integration suite.

## Changes
- Default `nvidia.VLM` model is now `meta/llama-3.2-11b-vision-instruct`
- Update plugin README, example, root README label, and changelog
- Integration fixture exercises the new default


Made with [Cursor](https://cursor.com)