### PR TITLE
[Fix] Metadata in agents is unset before setting the field

### DIFF
--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -82,7 +82,7 @@ _DRAIN_MARKER = PcmData(sample_rate=48000, format="s16", channels=1)
 # Metadata keys owned by components_metadata. Keys not describing a configured
 # component are set to None so the edge provider clears any stale value a
 # previous run of the same agent user wrote.
-_COMPONENT_METADATA_KEYS = (
+_COMPONENT_METADATA_KEYS: tuple[str, ...] = (
     "llm",
     "vlm",
     "realtime",
@@ -856,10 +856,10 @@ class Agent:
 
             with self.span("edge.authenticate"):
                 self.agent_user.custom = {
+                    **self.agent_user.custom,
                     **dict.fromkeys(_COMPONENT_METADATA_KEYS),
                     **self.components_metadata,
                     **{"is_agent": True},
-                    **self.agent_user.custom,
                 }
                 await self.edge.authenticate(self.agent_user)
                 self._agent_user_initialized = True

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -79,6 +79,20 @@ logger = logging.getLogger(__name__)
 # resampled — write(..., final=True) only flushes the tail — so the rate is inert.
 _DRAIN_MARKER = PcmData(sample_rate=48000, format="s16", channels=1)
 
+# Metadata keys owned by components_metadata. Keys not describing a configured
+# component are set to None so the edge provider clears any stale value a
+# previous run of the same agent user wrote.
+_COMPONENT_METADATA_KEYS = (
+    "llm",
+    "vlm",
+    "realtime",
+    "stt",
+    "tts",
+    "turn_detection",
+    "avatar",
+    "processors",
+)
+
 tracer: Tracer = trace.get_tracer("agents")
 
 
@@ -842,6 +856,7 @@ class Agent:
 
             with self.span("edge.authenticate"):
                 self.agent_user.custom = {
+                    **dict.fromkeys(_COMPONENT_METADATA_KEYS),
                     **self.components_metadata,
                     **{"is_agent": True},
                     **self.agent_user.custom,

--- a/plugins/getstream/tests/test_stream_edge_transport.py
+++ b/plugins/getstream/tests/test_stream_edge_transport.py
@@ -179,7 +179,10 @@ class TestStreamEdge:
             assert stored.custom == {"set_elsewhere": "keep me", "is_agent": True}
             assert "stt" not in stored.custom
         finally:
-            await edge.close()
+            try:
+                await edge.client.delete_users([user_id])
+            finally:
+                await edge.close()
 
     @pytest.mark.integration
     async def test_authenticate_omits_none_custom_on_create(self) -> None:
@@ -202,7 +205,10 @@ class TestStreamEdge:
             assert stored.custom == {"is_agent": True}
             assert "stt" not in stored.custom
         finally:
-            await edge.close()
+            try:
+                await edge.client.delete_users([user_id])
+            finally:
+                await edge.close()
 
     @pytest.mark.integration
     async def test_create_users_creates_users_that_do_not_exist_yet(self) -> None:

--- a/plugins/getstream/tests/test_stream_edge_transport.py
+++ b/plugins/getstream/tests/test_stream_edge_transport.py
@@ -148,6 +148,63 @@ class TestStreamEdge:
             await edge.close()
 
     @pytest.mark.integration
+    async def test_authenticate_unsets_none_custom_fields(self) -> None:
+        """None custom values remove stored fields without touching unrelated ones."""
+        edge = StreamEdge()
+        user_id = f"test-authenticate-unset-{uuid4()}"
+        try:
+            await edge.client.upsert_users(
+                UserRequest(
+                    id=user_id,
+                    name="Stored name",
+                    custom={
+                        "set_elsewhere": "keep me",
+                        "stt": {"provider": "deepgram"},
+                    },
+                )
+            )
+
+            await edge.authenticate(
+                User(
+                    id=user_id,
+                    name="Agent",
+                    custom={"is_agent": True, "stt": None},
+                )
+            )
+
+            response = await edge.client.query_users(
+                QueryUsersPayload(filter_conditions={"id": {"$eq": user_id}})
+            )
+            stored = response.data.users[0]
+            assert stored.custom == {"set_elsewhere": "keep me", "is_agent": True}
+            assert "stt" not in stored.custom
+        finally:
+            await edge.close()
+
+    @pytest.mark.integration
+    async def test_authenticate_omits_none_custom_on_create(self) -> None:
+        """404 create path omits null-valued custom fields instead of storing them."""
+        edge = StreamEdge()
+        user_id = f"test-authenticate-create-none-{uuid4()}"
+        try:
+            await edge.authenticate(
+                User(
+                    id=user_id,
+                    name="Agent",
+                    custom={"is_agent": True, "stt": None},
+                )
+            )
+
+            response = await edge.client.query_users(
+                QueryUsersPayload(filter_conditions={"id": {"$eq": user_id}})
+            )
+            stored = response.data.users[0]
+            assert stored.custom == {"is_agent": True}
+            assert "stt" not in stored.custom
+        finally:
+            await edge.close()
+
+    @pytest.mark.integration
     async def test_create_users_creates_users_that_do_not_exist_yet(self) -> None:
         edge = StreamEdge()
         user_id = f"test-create-users-{uuid4()}"

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -375,9 +375,7 @@ class StreamEdge(EdgeTransport[StreamCall]):
             if e.status_code != 404:
                 raise
             response = await self.client.upsert_users(
-                UserRequest(
-                    id=user.id, name=user.name, image=user.image, custom=custom
-                )
+                UserRequest(id=user.id, name=user.name, image=user.image, custom=custom)
             )
         return response.data.users[user.id]
 

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -355,23 +355,28 @@ class StreamEdge(EdgeTransport[StreamCall]):
         Upserting replaces the stored user, so custom data written by other
         clients would be lost. A partial update merges instead; it only fails
         when the user does not exist yet, in which case we create it.
+
+        A custom field set to None is removed from the stored user rather than
+        written as null.
         """
+        custom = {key: value for key, value in user.custom.items() if value is not None}
+        unset = [key for key, value in user.custom.items() if value is None]
         set_fields: dict[str, object] = {
             key: value
             for key, value in (("name", user.name), ("image", user.image))
             if value
         }
-        set_fields.update(user.custom)
+        set_fields.update(custom)
         try:
             response = await self.client.update_users_partial(
-                [UpdateUserPartialRequest(id=user.id, set=set_fields)]
+                [UpdateUserPartialRequest(id=user.id, set=set_fields, unset=unset)]
             )
         except StreamApiException as e:
             if e.status_code != 404:
                 raise
             response = await self.client.upsert_users(
                 UserRequest(
-                    id=user.id, name=user.name, image=user.image, custom=user.custom
+                    id=user.id, name=user.name, image=user.image, custom=custom
                 )
             )
         return response.data.users[user.id]

--- a/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
+++ b/plugins/getstream/vision_agents/plugins/getstream/stream_edge_transport.py
@@ -359,8 +359,10 @@ class StreamEdge(EdgeTransport[StreamCall]):
         A custom field set to None is removed from the stored user rather than
         written as null.
         """
-        custom = {key: value for key, value in user.custom.items() if value is not None}
-        unset = [key for key, value in user.custom.items() if value is None]
+        custom: dict[str, object] = {
+            key: value for key, value in user.custom.items() if value is not None
+        }
+        unset: list[str] = [key for key, value in user.custom.items() if value is None]
         set_fields: dict[str, object] = {
             key: value
             for key, value in (("name", user.name), ("image", user.image))

--- a/tests/test_agents/test_agents.py
+++ b/tests/test_agents/test_agents.py
@@ -435,7 +435,7 @@ class TestAgent:
         assert custom["tts"] == {"provider": "DummyTTS"}
 
     async def test_authenticate_preserves_user_supplied_custom(self):
-        """User-provided custom keys survive the metadata merge."""
+        """Non-managed user custom keys survive; framework owns component metadata."""
         agent = Agent(
             llm=DummyLLM(),
             tts=DummyTTS(),
@@ -446,9 +446,33 @@ class TestAgent:
         await agent.authenticate()
 
         custom = agent.agent_user.custom
-        assert custom["is_agent"] is False
+        assert custom["is_agent"] is True
         assert custom["team"] == "red"
         assert custom["llm"] == {"provider": "DummyLLM", "model": "llm"}
+
+    async def test_authenticate_clears_stale_managed_custom(self):
+        """Stale component keys in agent_user.custom cannot override current metadata."""
+        agent = Agent(
+            llm=DummyLLM(),
+            tts=DummyTTS(),
+            edge=DummyEdge(),
+            agent_user=User(
+                name="test",
+                custom={
+                    "stt": {"provider": "deepgram", "model": "flux-general-en"},
+                    "team": "red",
+                },
+            ),
+        )
+
+        await agent.authenticate()
+
+        custom = agent.agent_user.custom
+        assert custom["stt"] is None
+        assert custom["team"] == "red"
+        assert custom["llm"] == {"provider": "DummyLLM", "model": "llm"}
+        assert custom["tts"] == {"provider": "DummyTTS", "model": "tts"}
+        assert custom["is_agent"] is True
 
     async def test_send_metrics_event(self):
         """Test that metrics are sent as custom events."""


### PR DESCRIPTION
## Why

- when setting the metadata for e.g. a `realtime` model the TTS and STT fields were partially set
- this was wrong and therefore the FE would also show that information

## Changes

- clear the field before setting the specific values for this exact agent
