### PR TITLE
Metrics update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## New Features
 
-### Call metrics summary and richer session latency tracking
+### Call metrics summary and richer session latency tracking (#635)
 
 Session `AgentMetrics` now expose sample counts for every average (`*_ms__count`),
 error totals, turn counts, TTS time-to-first-audio, realtime time-to-first-audio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## New Features
 
+### Call metrics summary and richer session latency tracking
+
+Session `AgentMetrics` now expose sample counts for every average (`*_ms__count`),
+error totals, turn counts, TTS time-to-first-audio, realtime time-to-first-audio
+and session duration, and VLM time-to-first-token. On agent close the framework
+emits a best-effort `call_metrics_summary` custom event (mode, call duration,
+providers, flat metrics) so clients can show a post-call summary. Periodic
+`agent_metrics` broadcasts are unchanged.
+
 ### `telnyx` plugin: LLM, STT and TTS (#620, #621, #622)
 
 The Telnyx plugin, until now a phone transport, also exposes `telnyx.LLM`,

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -535,6 +535,8 @@ class Agent:
                 self._connection = await self.edge.join(self, call)
             self.logger.info(f"🤖 Agent joined call: {call.id}")
             self.events.send(events.AgentJoinedCallEvent(call=call))
+            # Call lifetime starts when we are on the SFU, not after warmup work.
+            self._joined_at = time.time()
 
             # Set up audio and video tracks together to avoid SDP issues
             audio_track = self._audio_track if self.publish_audio else None
@@ -574,7 +576,6 @@ class Agent:
                 )
 
             self._call_ended_event = asyncio.Event()
-            self._joined_at = time.time()
             yield
         except Exception as exc:
             if self._closing or self._closed:
@@ -801,13 +802,14 @@ class Agent:
         if self.conversation is not None:
             await self.conversation.wait_for_pending_syncs()
 
-        # Emit final call metrics while the edge connection is still up.
-        await self._emit_call_metrics_summary()
-
-        # Stop metrics broadcast task
+        # Stop metrics broadcast before the final summary so a late
+        # agent_metrics event cannot arrive after call_metrics_summary.
         if self._metrics_broadcast_task:
             await cancel_and_wait(self._metrics_broadcast_task)
             self._metrics_broadcast_task = None
+
+        # Emit final call metrics while the edge connection is still up.
+        await self._emit_call_metrics_summary()
 
         await self._stop_components()
 

--- a/agents-core/vision_agents/core/agents/agents.py
+++ b/agents-core/vision_agents/core/agents/agents.py
@@ -801,6 +801,9 @@ class Agent:
         if self.conversation is not None:
             await self.conversation.wait_for_pending_syncs()
 
+        # Emit final call metrics while the edge connection is still up.
+        await self._emit_call_metrics_summary()
+
         # Stop metrics broadcast task
         if self._metrics_broadcast_task:
             await cancel_and_wait(self._metrics_broadcast_task)
@@ -1296,6 +1299,49 @@ class Agent:
     @property
     def metrics(self) -> AgentMetrics:
         return self._collector.agent_metrics
+
+    def build_metrics_summary(self) -> dict[str, object]:
+        """Build a UI-friendly end-of-call metrics summary payload.
+
+        Returns:
+            A JSON-serializable dict with ``type``, ``mode``, ``call_duration_ms``,
+            ``providers``, and flat ``metrics``.
+        """
+        call_duration_ms: float | None = None
+        if self._joined_at:
+            call_duration_ms = (time.time() - self._joined_at) * 1000
+
+        providers: dict[str, str | None] = {}
+        if _is_realtime_llm(self.llm):
+            providers["realtime"] = self.llm.provider_name
+        else:
+            providers["llm"] = self.llm.provider_name
+        if self.stt is not None:
+            providers["stt"] = self.stt.provider_name
+        if self.tts is not None:
+            providers["tts"] = self.tts.provider_name
+        if self.turn_detection is not None:
+            providers["turn_detection"] = self.turn_detection.provider_name
+
+        return {
+            "type": "call_metrics_summary",
+            "mode": self.metrics.infer_mode(),
+            "call_duration_ms": call_duration_ms,
+            "providers": providers,
+            "metrics": self.metrics.to_dict(),
+        }
+
+    async def _emit_call_metrics_summary(self) -> None:
+        """Best-effort emit of the final call metrics summary custom event."""
+        if self._connection is None:
+            return
+        try:
+            await self.send_custom_event(self.build_metrics_summary())
+        except RuntimeError:
+            # Call already torn down on the edge — nothing to deliver to.
+            self.logger.debug("Skipping call_metrics_summary: not connected")
+        except Exception:
+            self.logger.exception("Failed to emit call_metrics_summary event")
 
     async def send_custom_event(self, data: dict) -> None:
         """Send a custom event to all participants watching the call.

--- a/agents-core/vision_agents/core/llm/realtime.py
+++ b/agents-core/vision_agents/core/llm/realtime.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 import logging
+import time
 import uuid
 from collections.abc import Coroutine
 from dataclasses import dataclass
@@ -135,6 +136,12 @@ class Realtime(OmniLLM):
             | RealtimeAgentSpeechEnded
         ] = Stream()
 
+        # Session / TTFA tracking: start clock on user speech end, record once
+        # on the first audio output chunk of that response.
+        self._session_started_at: float | None = None
+        self._pending_response_started_at: float | None = None
+        self._ttfa_recorded: bool = False
+
     @property
     def output(
         self,
@@ -168,6 +175,8 @@ class Realtime(OmniLLM):
         """Increment epoch so stale audio output events are discarded."""
         self._epoch += 1
         self._current_participant = None
+        self._pending_response_started_at = None
+        self._ttfa_recorded = False
         self._audio_input_processor.clear()
         self._output.clear()
 
@@ -191,6 +200,11 @@ class Realtime(OmniLLM):
 
     async def process_audio(self, pcm: PcmData, participant: Participant) -> None:
         self._current_participant = participant
+        self.metrics.on_realtime_audio_input(
+            byte_count=pcm.samples.nbytes,
+            duration_ms=pcm.duration_ms,
+            provider=self.provider_name,
+        )
         await self._audio_input_processor.process_audio(pcm, participant)
 
     async def _close_audio_input(self) -> None:
@@ -207,6 +221,8 @@ class Realtime(OmniLLM):
     ):
         """Mark the session connected and emit RealtimeConnectedEvent."""
         self.connected = True
+        self._session_started_at = time.perf_counter()
+        self.metrics.on_realtime_session_started(provider=self.provider_name)
         self.events.send(
             RealtimeConnectedEvent(
                 plugin_name=self.provider_name,
@@ -220,6 +236,13 @@ class Realtime(OmniLLM):
         """Mark the session disconnected and emit RealtimeDisconnectedEvent."""
         self.connected = False
         self._audio_input_processor.clear()
+        duration_ms: float | None = None
+        if self._session_started_at is not None:
+            duration_ms = (time.perf_counter() - self._session_started_at) * 1000
+            self._session_started_at = None
+        self.metrics.on_realtime_session_ended(
+            provider=self.provider_name, duration_ms=duration_ms
+        )
         self.events.send(
             RealtimeDisconnectedEvent(
                 plugin_name=self.provider_name,
@@ -229,8 +252,26 @@ class Realtime(OmniLLM):
             )
         )
 
+    def _mark_response_started(self) -> None:
+        """Mark the start of a realtime response for TTFA measurement."""
+        self._pending_response_started_at = time.perf_counter()
+        self._ttfa_recorded = False
+
+    def _record_ttfa_if_needed(self) -> None:
+        """Record TTFA once on the first audio output after speech end."""
+        if self._ttfa_recorded or self._pending_response_started_at is None:
+            return
+        ttfa_ms = (time.perf_counter() - self._pending_response_started_at) * 1000
+        self._ttfa_recorded = True
+        self._pending_response_started_at = None
+        self.metrics.on_realtime_time_to_first_audio(
+            provider=self.provider_name,
+            time_to_first_audio_ms=ttfa_ms,
+        )
+
     def _emit_audio_output_event(self, pcm: PcmData, response_id: str | None = None):
         """Emit a structured audio output event."""
+        self._record_ttfa_if_needed()
         event = RealtimeAudioOutput(
             data=pcm,
             response_id=response_id,
@@ -263,6 +304,7 @@ class Realtime(OmniLLM):
 
     def _emit_user_speech_ended(self):
         """Emit a user-speech-ended signal from server-side VAD."""
+        self._mark_response_started()
         if self._current_participant is None:
             return
         self._output.send_nowait(

--- a/agents-core/vision_agents/core/observability/__init__.py
+++ b/agents-core/vision_agents/core/observability/__init__.py
@@ -32,6 +32,7 @@ from .metrics import (
     realtime_session_duration_ms,
     # Realtime LLM metrics
     realtime_sessions,
+    realtime_time_to_first_audio_ms,
     realtime_user_transcriptions,
     stt_audio_duration_ms,
     stt_errors,
@@ -42,6 +43,7 @@ from .metrics import (
     tts_errors,
     # TTS metrics
     tts_latency_ms,
+    tts_time_to_first_audio_ms,
     # Turn detection metrics
     turn_duration_ms,
     turn_trailing_silence_ms,
@@ -55,6 +57,7 @@ from .metrics import (
     vlm_inferences,
     vlm_input_tokens,
     vlm_output_tokens,
+    vlm_time_to_first_token_ms,
 )
 
 __all__ = [
@@ -68,6 +71,7 @@ __all__ = [
     "stt_errors",
     # TTS metrics
     "tts_latency_ms",
+    "tts_time_to_first_audio_ms",
     "tts_audio_duration_ms",
     "tts_characters",
     "tts_errors",
@@ -85,6 +89,7 @@ __all__ = [
     # Realtime LLM metrics
     "realtime_sessions",
     "realtime_session_duration_ms",
+    "realtime_time_to_first_audio_ms",
     "realtime_audio_input_bytes",
     "realtime_audio_output_bytes",
     "realtime_audio_input_duration_ms",
@@ -95,6 +100,7 @@ __all__ = [
     "realtime_errors",
     # VLM metrics
     "vlm_inference_latency_ms",
+    "vlm_time_to_first_token_ms",
     "vlm_inferences",
     "vlm_input_tokens",
     "vlm_output_tokens",

--- a/agents-core/vision_agents/core/observability/agent.py
+++ b/agents-core/vision_agents/core/observability/agent.py
@@ -216,7 +216,9 @@ class AgentMetrics:
                 metric.inc(int(value))
             elif isinstance(metric, Average):
                 count = data.get(cls.count_field_name(f.name))
-                if isinstance(count, (int, float)) and count > 0:
+                if isinstance(count, int) and count > 0:
+                    metric.load(float(value), count)
+                elif isinstance(count, float) and count.is_integer() and count > 0:
                     metric.load(float(value), int(count))
                 else:
                     metric.update(value)
@@ -265,6 +267,7 @@ class AgentMetrics:
             or self.stt_latency_ms__avg.count > 0
             or self.tts_latency_ms__avg.count > 0
             or self.tts_time_to_first_audio_ms__avg.count > 0
+            or self.vlm_inferences__total.value() > 0
         )
         has_realtime = (
             self.realtime_responses__total.value() > 0

--- a/agents-core/vision_agents/core/observability/agent.py
+++ b/agents-core/vision_agents/core/observability/agent.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 from dataclasses import dataclass, field
-from typing import Iterable
+from typing import Iterable, Literal
 
 
 class _Metric(abc.ABC):
@@ -41,11 +41,26 @@ class Average(_Metric):
         self._total += 1
         self._sum += value
 
+    def load(self, average: float, count: int) -> None:
+        """Replace the running average with a known average and sample count."""
+        if count <= 0:
+            return
+        self._total = count
+        self._sum = average * count
+
+    @property
+    def count(self) -> int:
+        """Number of samples contributing to the average."""
+        return self._total
+
     def value(self) -> float | None:
         if not self._total:
             return None
 
         return self._sum / self._total
+
+
+MetricsMode = Literal["pipeline", "realtime", "hybrid"]
 
 
 @dataclass(frozen=True)
@@ -61,9 +76,16 @@ class AgentMetrics:
     stt_audio_duration_ms__total: Counter = field(
         default_factory=lambda: Counter("Duration of audio processed by STT")
     )
+    stt_errors__total: Counter = field(default_factory=lambda: Counter("STT errors"))
+
     # TTS Metrics
     tts_latency_ms__avg: Average = field(
-        default_factory=lambda: Average("TTS synthesis latency")
+        default_factory=lambda: Average(
+            "TTS total synthesis latency (request to complete)"
+        )
+    )
+    tts_time_to_first_audio_ms__avg: Average = field(
+        default_factory=lambda: Average("TTS time to first audio chunk")
     )
     tts_audio_duration_ms__total: Counter = field(
         default_factory=lambda: Counter("Duration of synthesized audio")
@@ -71,6 +93,7 @@ class AgentMetrics:
     tts_characters__total: Counter = field(
         default_factory=lambda: Counter("Characters synthesized by TTS")
     )
+    tts_errors__total: Counter = field(default_factory=lambda: Counter("TTS errors"))
 
     # LLM Metrics
     llm_latency_ms__avg: Average = field(
@@ -93,8 +116,12 @@ class AgentMetrics:
     llm_tool_latency_ms__avg: Average = field(
         default_factory=lambda: Average("Average LLM tool execution latency")
     )
+    llm_errors__total: Counter = field(default_factory=lambda: Counter("LLM errors"))
 
     # Turn Detection Metrics
+    turns__total: Counter = field(
+        default_factory=lambda: Counter("Conversational turns detected")
+    )
     turn_duration_ms__avg: Average = field(
         default_factory=lambda: Average("Average duration of detected turns")
     )
@@ -105,6 +132,17 @@ class AgentMetrics:
     )
 
     # Realtime LLM Metrics
+    realtime_time_to_first_audio_ms__avg: Average = field(
+        default_factory=lambda: Average(
+            "Realtime time to first audio (speech end to first output)"
+        )
+    )
+    realtime_session_duration_ms__avg: Average = field(
+        default_factory=lambda: Average("Average realtime session duration")
+    )
+    realtime_responses__total: Counter = field(
+        default_factory=lambda: Counter("Realtime LLM responses completed")
+    )
     realtime_audio_input_bytes__total: Counter = field(
         default_factory=lambda: Counter("Audio bytes sent to realtime LLM")
     )
@@ -123,10 +161,16 @@ class AgentMetrics:
     realtime_agent_transcriptions__total: Counter = field(
         default_factory=lambda: Counter("Agent speech transcriptions from realtime LLM")
     )
+    realtime_errors__total: Counter = field(
+        default_factory=lambda: Counter("Realtime LLM errors")
+    )
 
     # VLM / Vision Metrics
     vlm_inference_latency_ms__avg: Average = field(
         default_factory=lambda: Average("Average VLM inference latency")
+    )
+    vlm_time_to_first_token_ms__avg: Average = field(
+        default_factory=lambda: Average("Average VLM time to first token (streaming)")
     )
     vlm_inferences__total: Counter = field(
         default_factory=lambda: Counter("VLM inference requests")
@@ -137,6 +181,7 @@ class AgentMetrics:
     vlm_output_tokens__total: Counter = field(
         default_factory=lambda: Counter("VLM output tokens")
     )
+    vlm_errors__total: Counter = field(default_factory=lambda: Counter("VLM errors"))
 
     # Video Processor Metrics
     video_frames_processed__total: Counter = field(
@@ -146,12 +191,20 @@ class AgentMetrics:
         default_factory=lambda: Average("Average video frame processing latency")
     )
 
+    @staticmethod
+    def count_field_name(avg_field_name: str) -> str:
+        """Map an ``__avg`` field name to its companion ``__count`` key."""
+        if not avg_field_name.endswith("__avg"):
+            raise ValueError(f"Not an average field: {avg_field_name}")
+        return avg_field_name[: -len("__avg")] + "__count"
+
     @classmethod
     def from_dict(cls, data: dict[str, int | float | None]) -> "AgentMetrics":
         """Reconstruct metrics from a flat dictionary of values.
 
         Args:
-            data: mapping of metric name to its scalar value.
+            data: mapping of metric name to its scalar value. Companion
+                ``__count`` keys restore average sample counts when present.
         """
         metrics = cls()
         for f in dataclasses.fields(metrics):
@@ -162,27 +215,65 @@ class AgentMetrics:
             if isinstance(metric, Counter):
                 metric.inc(int(value))
             elif isinstance(metric, Average):
-                metric.update(value)
+                count = data.get(cls.count_field_name(f.name))
+                if isinstance(count, (int, float)) and count > 0:
+                    metric.load(float(value), int(count))
+                else:
+                    metric.update(value)
         return metrics
 
     def to_dict(self, fields: Iterable[str] = ()) -> dict[str, int | float | None]:
-        """
-        Convert metrics into a dictionary {<metric>: <value>}.
+        """Convert metrics into a flat dictionary.
+
+        Every included ``__avg`` field also emits a companion ``__count`` key.
 
         Args:
-            fields: optional list of fields to extract. If empty, extract all fields.
+            fields: optional list of fields to extract. If empty, extract all
+                metric fields plus companion counts for averages.
 
         Returns:
             a dictionary {<metric>: <value>}
-
         """
-        all_fields = dataclasses.asdict(self)
-        result = {}
-        fields = fields or list(all_fields.keys())
+        field_by_name = {f.name: f for f in dataclasses.fields(self)}
+        requested = list(fields) if fields else list(field_by_name)
 
-        for field_name in fields:
-            field_ = all_fields.get(field_name)
-            if field_ is None:
+        result: dict[str, int | float | None] = {}
+        for field_name in requested:
+            if field_name.endswith("__count"):
+                avg_name = field_name[: -len("__count")] + "__avg"
+                if avg_name not in field_by_name:
+                    raise ValueError(f"Unknown field: {field_name}")
+                avg_metric = getattr(self, avg_name)
+                if not isinstance(avg_metric, Average):
+                    raise ValueError(f"Unknown field: {field_name}")
+                result[field_name] = avg_metric.count
+                continue
+
+            if field_name not in field_by_name:
                 raise ValueError(f"Unknown field: {field_name}")
-            result[field_name] = field_.value()
+            metric = getattr(self, field_name)
+            result[field_name] = metric.value()
+            if isinstance(metric, Average):
+                result[self.count_field_name(field_name)] = metric.count
+
         return result
+
+    def infer_mode(self) -> MetricsMode:
+        """Infer whether this session used pipeline, realtime, or both."""
+        has_pipeline = (
+            self.llm_latency_ms__avg.count > 0
+            or self.stt_latency_ms__avg.count > 0
+            or self.tts_latency_ms__avg.count > 0
+            or self.tts_time_to_first_audio_ms__avg.count > 0
+        )
+        has_realtime = (
+            self.realtime_responses__total.value() > 0
+            or self.realtime_time_to_first_audio_ms__avg.count > 0
+            or self.realtime_audio_output_duration_ms__total.value() > 0
+            or self.realtime_user_transcriptions__total.value() > 0
+        )
+        if has_pipeline and has_realtime:
+            return "hybrid"
+        if has_realtime:
+            return "realtime"
+        return "pipeline"

--- a/agents-core/vision_agents/core/observability/collector.py
+++ b/agents-core/vision_agents/core/observability/collector.py
@@ -136,6 +136,8 @@ class MetricsCollector:
         error_code: str | None = None,
     ) -> None:
         """Record an LLM error."""
+        self.agent_metrics.llm_errors__total.inc(1)
+
         if self.parent is not None:
             self.parent.on_llm_error(
                 provider=provider, error_type=error_type, error_code=error_code
@@ -154,6 +156,62 @@ class MetricsCollector:
     # =========================================================================
     # Realtime LLM
     # =========================================================================
+
+    def on_realtime_session_started(self, *, provider: str | None = None) -> None:
+        """Record a realtime session start."""
+        if self.parent is not None:
+            self.parent.on_realtime_session_started(provider=provider)
+            return
+
+        attrs: dict = {}
+        if provider:
+            attrs["provider"] = provider
+        metrics.realtime_sessions.add(1, attrs)
+
+    def on_realtime_session_ended(
+        self,
+        *,
+        provider: str | None = None,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Record a realtime session end."""
+        if duration_ms is not None:
+            self.agent_metrics.realtime_session_duration_ms__avg.update(duration_ms)
+
+        if self.parent is not None:
+            self.parent.on_realtime_session_ended(
+                provider=provider, duration_ms=duration_ms
+            )
+            return
+
+        attrs: dict = {}
+        if provider:
+            attrs["provider"] = provider
+        if duration_ms is not None:
+            metrics.realtime_session_duration_ms.record(duration_ms, attrs)
+
+    def on_realtime_time_to_first_audio(
+        self,
+        *,
+        provider: str | None = None,
+        time_to_first_audio_ms: float,
+    ) -> None:
+        """Record realtime time to first audio for a response."""
+        self.agent_metrics.realtime_time_to_first_audio_ms__avg.update(
+            time_to_first_audio_ms
+        )
+
+        if self.parent is not None:
+            self.parent.on_realtime_time_to_first_audio(
+                provider=provider,
+                time_to_first_audio_ms=time_to_first_audio_ms,
+            )
+            return
+
+        attrs: dict = {}
+        if provider:
+            attrs["provider"] = provider
+        metrics.realtime_time_to_first_audio_ms.record(time_to_first_audio_ms, attrs)
 
     def on_realtime_audio_input(
         self,
@@ -211,6 +269,8 @@ class MetricsCollector:
 
     def on_realtime_response_completed(self, *, provider: str | None = None) -> None:
         """Record a completed realtime response."""
+        self.agent_metrics.realtime_responses__total.inc(1)
+
         if self.parent is not None:
             self.parent.on_realtime_response_completed(provider=provider)
             return
@@ -255,6 +315,8 @@ class MetricsCollector:
         is_recoverable: bool = False,
     ) -> None:
         """Record a realtime LLM error."""
+        self.agent_metrics.realtime_errors__total.inc(1)
+
         if self.parent is not None:
             self.parent.on_realtime_error(
                 provider=provider,
@@ -322,6 +384,8 @@ class MetricsCollector:
         error_code: str | None = None,
     ) -> None:
         """Record an STT error."""
+        self.agent_metrics.stt_errors__total.inc(1)
+
         if self.parent is not None:
             self.parent.on_stt_error(
                 provider=provider, error_type=error_type, error_code=error_code
@@ -346,12 +410,17 @@ class MetricsCollector:
         *,
         provider: str | None = None,
         synthesis_time_ms: float | None = None,
+        time_to_first_audio_ms: float | None = None,
         audio_duration_ms: float | None = None,
         character_count: int | None = None,
     ) -> None:
         """Record a completed TTS synthesis."""
         if synthesis_time_ms is not None:
             self.agent_metrics.tts_latency_ms__avg.update(synthesis_time_ms)
+        if time_to_first_audio_ms is not None:
+            self.agent_metrics.tts_time_to_first_audio_ms__avg.update(
+                time_to_first_audio_ms
+            )
         if audio_duration_ms is not None:
             self.agent_metrics.tts_audio_duration_ms__total.inc(int(audio_duration_ms))
         if character_count is not None:
@@ -361,6 +430,7 @@ class MetricsCollector:
             self.parent.on_tts_synthesis(
                 provider=provider,
                 synthesis_time_ms=synthesis_time_ms,
+                time_to_first_audio_ms=time_to_first_audio_ms,
                 audio_duration_ms=audio_duration_ms,
                 character_count=character_count,
             )
@@ -371,6 +441,8 @@ class MetricsCollector:
             attrs["provider"] = provider
         if synthesis_time_ms is not None:
             metrics.tts_latency_ms.record(synthesis_time_ms, attrs)
+        if time_to_first_audio_ms is not None:
+            metrics.tts_time_to_first_audio_ms.record(time_to_first_audio_ms, attrs)
         if audio_duration_ms is not None:
             metrics.tts_audio_duration_ms.record(audio_duration_ms, attrs)
         if character_count is not None:
@@ -384,6 +456,8 @@ class MetricsCollector:
         error_code: str | None = None,
     ) -> None:
         """Record a TTS error."""
+        self.agent_metrics.tts_errors__total.inc(1)
+
         if self.parent is not None:
             self.parent.on_tts_error(
                 provider=provider, error_type=error_type, error_code=error_code
@@ -411,6 +485,7 @@ class MetricsCollector:
         trailing_silence_ms: float | None = None,
     ) -> None:
         """Record a completed conversational turn."""
+        self.agent_metrics.turns__total.inc(1)
         if duration_ms is not None:
             self.agent_metrics.turn_duration_ms__avg.update(duration_ms)
         if trailing_silence_ms is not None:
@@ -442,6 +517,7 @@ class MetricsCollector:
         provider: str | None = None,
         model: str | None = None,
         latency_ms: float | None = None,
+        time_to_first_token_ms: float | None = None,
         input_tokens: int | None = None,
         output_tokens: int | None = None,
         frames_processed: int = 0,
@@ -451,6 +527,10 @@ class MetricsCollector:
         self.agent_metrics.vlm_inferences__total.inc(1)
         if latency_ms is not None:
             self.agent_metrics.vlm_inference_latency_ms__avg.update(latency_ms)
+        if time_to_first_token_ms is not None:
+            self.agent_metrics.vlm_time_to_first_token_ms__avg.update(
+                time_to_first_token_ms
+            )
         if input_tokens is not None:
             self.agent_metrics.vlm_input_tokens__total.inc(input_tokens)
         if output_tokens is not None:
@@ -463,6 +543,7 @@ class MetricsCollector:
                 provider=provider,
                 model=model,
                 latency_ms=latency_ms,
+                time_to_first_token_ms=time_to_first_token_ms,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 frames_processed=frames_processed,
@@ -478,6 +559,8 @@ class MetricsCollector:
         metrics.vlm_inferences.add(1, attrs)
         if latency_ms is not None:
             metrics.vlm_inference_latency_ms.record(latency_ms, attrs)
+        if time_to_first_token_ms is not None:
+            metrics.vlm_time_to_first_token_ms.record(time_to_first_token_ms, attrs)
         if input_tokens is not None:
             metrics.vlm_input_tokens.add(input_tokens, attrs)
         if output_tokens is not None:
@@ -495,6 +578,8 @@ class MetricsCollector:
         error_code: str | None = None,
     ) -> None:
         """Record a VLM error."""
+        self.agent_metrics.vlm_errors__total.inc(1)
+
         if self.parent is not None:
             self.parent.on_vlm_error(
                 provider=provider, error_type=error_type, error_code=error_code

--- a/agents-core/vision_agents/core/observability/metrics.py
+++ b/agents-core/vision_agents/core/observability/metrics.py
@@ -63,7 +63,12 @@ stt_errors = meter.create_counter(
 tts_latency_ms = meter.create_histogram(
     "tts.latency.ms",
     unit="ms",
-    description="TTS synthesis latency",
+    description="TTS total synthesis latency (request to complete)",
+)
+tts_time_to_first_audio_ms = meter.create_histogram(
+    "tts.time_to_first_audio.ms",
+    unit="ms",
+    description="TTS time to first audio chunk",
 )
 tts_audio_duration_ms = meter.create_histogram(
     "tts.audio_duration.ms",
@@ -176,6 +181,11 @@ realtime_errors = meter.create_counter(
     "realtime.errors",
     description="Realtime LLM errors",
 )
+realtime_time_to_first_audio_ms = meter.create_histogram(
+    "realtime.time_to_first_audio.ms",
+    unit="ms",
+    description="Realtime time to first audio (speech end to first output)",
+)
 
 # =============================================================================
 # VLM / Vision Metrics
@@ -184,6 +194,11 @@ vlm_inference_latency_ms = meter.create_histogram(
     "vlm.inference.latency.ms",
     unit="ms",
     description="VLM inference latency",
+)
+vlm_time_to_first_token_ms = meter.create_histogram(
+    "vlm.time_to_first_token.ms",
+    unit="ms",
+    description="VLM time to first token (streaming)",
 )
 vlm_inferences = meter.create_counter(
     "vlm.inferences",

--- a/agents-core/vision_agents/core/tts/events.py
+++ b/agents-core/vision_agents/core/tts/events.py
@@ -40,6 +40,7 @@ class TTSSynthesisCompleteEvent(PluginBaseEvent):
     text: Optional[str] = None
     total_audio_bytes: int = 0
     synthesis_time_ms: float = 0.0
+    time_to_first_audio_ms: Optional[float] = None
     audio_duration_ms: Optional[float] = None
     chunk_count: int = 1
     real_time_factor: Optional[float] = None

--- a/agents-core/vision_agents/core/tts/tts.py
+++ b/agents-core/vision_agents/core/tts/tts.py
@@ -250,10 +250,11 @@ class TTS(Component):
             total_audio_bytes = 0
             total_audio_ms = 0.0
             chunk_index = 0
+            time_to_first_audio_s: float | None = None
 
-            # Fast-path: single buffer -> mark final
-            synthesis_time = time.perf_counter() - start_time
             if isinstance(response, PcmData):
+                # Single buffer: TTFA equals total synthesis time.
+                time_to_first_audio_s = time.perf_counter() - start_time
                 bytes_len, duration_ms = len(response.samples), response.duration_ms
                 yield TTSOutputChunk(
                     data=response,
@@ -269,9 +270,8 @@ class TTS(Component):
                 async for pcm in self._iter_pcm(response):
                     if epoch != self._epoch:
                         return
-                    # Register the synthesis time only when we get the first chunk
                     if chunk_index == 0:
-                        synthesis_time = time.perf_counter() - start_time
+                        time_to_first_audio_s = time.perf_counter() - start_time
 
                     bytes_len, duration_ms = len(pcm.samples), pcm.duration_ms
                     yield TTSOutputChunk(
@@ -297,11 +297,18 @@ class TTS(Component):
                         text=text,
                     )
 
-            # Use accumulated PcmData duration for total audio duration
+            # Total wall-clock time from request start to synthesis complete.
+            synthesis_time_s = time.perf_counter() - start_time
             estimated_audio_duration_ms = total_audio_ms
+            synthesis_time_ms = synthesis_time_s * 1000
+            ttfa_ms = (
+                time_to_first_audio_s * 1000
+                if time_to_first_audio_s is not None
+                else None
+            )
 
             real_time_factor = (
-                (synthesis_time * 1000) / estimated_audio_duration_ms
+                synthesis_time_ms / estimated_audio_duration_ms
                 if estimated_audio_duration_ms > 0
                 else None
             )
@@ -313,7 +320,8 @@ class TTS(Component):
                     text=text,
                     participant=participant,
                     total_audio_bytes=total_audio_bytes,
-                    synthesis_time_ms=synthesis_time * 1000,
+                    synthesis_time_ms=synthesis_time_ms,
+                    time_to_first_audio_ms=ttfa_ms,
                     audio_duration_ms=estimated_audio_duration_ms,
                     chunk_count=chunk_index,
                     real_time_factor=real_time_factor,
@@ -321,7 +329,8 @@ class TTS(Component):
             )
             self.metrics.on_tts_synthesis(
                 provider=self.provider_name,
-                synthesis_time_ms=synthesis_time * 1000,
+                synthesis_time_ms=synthesis_time_ms,
+                time_to_first_audio_ms=ttfa_ms,
                 audio_duration_ms=estimated_audio_duration_ms,
                 character_count=len(text),
             )

--- a/examples/01_simple_agent_example/simple_agent_example.py
+++ b/examples/01_simple_agent_example/simple_agent_example.py
@@ -53,6 +53,7 @@ async def create_agent(**kwargs) -> Agent:
         # turn_detection=vogent.TurnDetection(), # smart turn and vogent are supported. not needed with deepgram (it has turn keeping)
         # realtime openai and gemini are supported (tts and stt not needed in that case)
         # llm=openai.Realtime()
+        broadcast_metrics=True,
     )
 
     return agent

--- a/plugins/gemini/vision_agents/plugins/gemini/gemini_vlm.py
+++ b/plugins/gemini/vision_agents/plugins/gemini/gemini_vlm.py
@@ -202,6 +202,7 @@ class GeminiVLM(VideoLLM):
                 provider=self.provider_name,
                 model=self.model,
                 latency_ms=latency_ms,
+                time_to_first_token_ms=ttft_ms,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 frames_processed=frames_count,

--- a/plugins/huggingface/vision_agents/plugins/huggingface/huggingface_vlm.py
+++ b/plugins/huggingface/vision_agents/plugins/huggingface/huggingface_vlm.py
@@ -131,6 +131,7 @@ class HuggingFaceVLM(VideoLLM):
                     provider=self.provider_name,
                     model=self.model,
                     latency_ms=item.latency_ms,
+                    time_to_first_token_ms=item.time_to_first_token_ms,
                     input_tokens=item.input_tokens,
                     output_tokens=item.output_tokens,
                     frames_processed=frames_count,

--- a/plugins/huggingface/vision_agents/plugins/huggingface/transformers_vlm.py
+++ b/plugins/huggingface/vision_agents/plugins/huggingface/transformers_vlm.py
@@ -354,6 +354,7 @@ class TransformersVLM(VideoLLM, Warmable[VLMResources]):
             )
             if not tool_calls:
                 response_id = str(uuid.uuid4())
+                # Batch generate returns all tokens at once, so TTFT ≈ latency.
                 if output_text:
                     yield LLMResponseDelta(
                         content_index=None,
@@ -362,13 +363,14 @@ class TransformersVLM(VideoLLM, Warmable[VLMResources]):
                         sequence_number=0,
                         delta=output_text,
                         is_first_chunk=True,
-                        time_to_first_token_ms=None,
+                        time_to_first_token_ms=latency_ms,
                     )
                 yield LLMResponseFinal(
                     original=outputs,
                     text=output_text,
                     item_id=response_id,
                     latency_ms=latency_ms,
+                    time_to_first_token_ms=latency_ms,
                     model=self.model_id,
                 )
                 return

--- a/plugins/huggingface/vision_agents/plugins/huggingface/transformers_vlm.py
+++ b/plugins/huggingface/vision_agents/plugins/huggingface/transformers_vlm.py
@@ -247,6 +247,7 @@ class TransformersVLM(VideoLLM, Warmable[VLMResources]):
                     provider=self.provider_name,
                     model=self.model_id,
                     latency_ms=item.latency_ms,
+                    time_to_first_token_ms=item.time_to_first_token_ms,
                     input_tokens=item.input_tokens,
                     output_tokens=item.output_tokens,
                     frames_processed=len(frames_snapshot),

--- a/plugins/moondream/vision_agents/plugins/moondream/vlm/moondream_cloud_vlm.py
+++ b/plugins/moondream/vision_agents/plugins/moondream/vlm/moondream_cloud_vlm.py
@@ -195,6 +195,7 @@ class CloudVLM(llm.VideoLLM):
                 provider=self.provider_name,
                 model="moondream-cloud",
                 latency_ms=latency_ms,
+                time_to_first_token_ms=final_ttft_ms,
                 frames_processed=1,
             )
 

--- a/plugins/moondream/vision_agents/plugins/moondream/vlm/moondream_local_vlm.py
+++ b/plugins/moondream/vision_agents/plugins/moondream/vlm/moondream_local_vlm.py
@@ -319,6 +319,7 @@ class LocalVLM(llm.VideoLLM, Warmable):
                     provider=self.provider_name,
                     model=self.model_name,
                     latency_ms=latency_ms,
+                    time_to_first_token_ms=final_ttft_ms,
                     frames_processed=1,
                 )
 

--- a/plugins/nvidia/vision_agents/plugins/nvidia/nvidia_vlm.py
+++ b/plugins/nvidia/vision_agents/plugins/nvidia/nvidia_vlm.py
@@ -316,6 +316,13 @@ class NvidiaVLM(VideoLLM):
                 if first_token_time is not None:
                     ttft_ms = (first_token_time - request_start_time) * 1000
 
+                self.metrics.on_vlm_inference(
+                    provider=self.provider_name,
+                    model=self.model,
+                    latency_ms=latency_ms,
+                    time_to_first_token_ms=ttft_ms,
+                )
+
                 yield LLMResponseFinal(
                     original=last_chunk_data,
                     text=total_text,

--- a/plugins/nvidia/vision_agents/plugins/nvidia/nvidia_vlm.py
+++ b/plugins/nvidia/vision_agents/plugins/nvidia/nvidia_vlm.py
@@ -54,6 +54,8 @@ class NvidiaVLM(VideoLLM):
 
     """
 
+    provider_name = PLUGIN_NAME
+
     def __init__(
         self,
         model: str = "meta/llama-3.2-11b-vision-instruct",

--- a/plugins/openai/vision_agents/plugins/openai/chat_completions/chat_completions_vlm.py
+++ b/plugins/openai/vision_agents/plugins/openai/chat_completions/chat_completions_vlm.py
@@ -195,6 +195,7 @@ class ChatCompletionsVLM(VideoLLM):
             provider=self.provider_name,
             model=self.model,
             latency_ms=latency_ms,
+            time_to_first_token_ms=ttft_ms,
             frames_processed=frames_count,
         )
 

--- a/plugins/twelvelabs/vision_agents/plugins/twelvelabs/pegasus_vlm.py
+++ b/plugins/twelvelabs/vision_agents/plugins/twelvelabs/pegasus_vlm.py
@@ -220,6 +220,7 @@ class PegasusVLM(llm.VideoLLM):
                 provider=self.provider_name,
                 model=self.model,
                 latency_ms=latency_ms,
+                time_to_first_token_ms=final_ttft_ms,
                 frames_processed=len(frames),
             )
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -489,3 +489,23 @@ class TestAgentMetrics:
         metrics.stt_latency_ms__avg.update(50)
         metrics.realtime_time_to_first_audio_ms__avg.update(80)
         assert metrics.infer_mode() == "hybrid"
+
+    def test_infer_mode_hybrid_realtime_plus_vlm(self):
+        metrics = AgentMetrics()
+        metrics.realtime_responses__total.inc(1)
+        metrics.vlm_inferences__total.inc(1)
+        assert metrics.infer_mode() == "hybrid"
+
+    def test_from_dict_rejects_fractional_count(self):
+        metrics = AgentMetrics.from_dict(
+            {"llm_latency_ms__avg": 100.0, "llm_latency_ms__count": 1.5}
+        )
+        assert metrics.llm_latency_ms__avg.value() == 100.0
+        assert metrics.llm_latency_ms__avg.count == 1
+
+    def test_from_dict_accepts_integral_float_count(self):
+        metrics = AgentMetrics.from_dict(
+            {"llm_latency_ms__avg": 100.0, "llm_latency_ms__count": 2.0}
+        )
+        assert metrics.llm_latency_ms__avg.value() == 100.0
+        assert metrics.llm_latency_ms__avg.count == 2

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -15,6 +15,10 @@ from vision_agents.core.observability.metrics import (
     llm_tool_calls,
     llm_tool_latency_ms,
     meter,
+    realtime_responses,
+    realtime_session_duration_ms,
+    realtime_sessions,
+    realtime_time_to_first_audio_ms,
     stt_audio_duration_ms,
     stt_errors,
     stt_latency_ms,
@@ -22,6 +26,7 @@ from vision_agents.core.observability.metrics import (
     tts_characters,
     tts_errors,
     tts_latency_ms,
+    tts_time_to_first_audio_ms,
     turn_duration_ms,
     turn_trailing_silence_ms,
     video_detections,
@@ -31,6 +36,7 @@ from vision_agents.core.observability.metrics import (
     vlm_inferences,
     vlm_input_tokens,
     vlm_output_tokens,
+    vlm_time_to_first_token_ms,
 )
 
 
@@ -46,6 +52,10 @@ def mock_metrics():
         llm_tool_calls,
         llm_tool_latency_ms,
         meter,
+        realtime_responses,
+        realtime_session_duration_ms,
+        realtime_sessions,
+        realtime_time_to_first_audio_ms,
         stt_audio_duration_ms,
         stt_errors,
         stt_latency_ms,
@@ -53,6 +63,7 @@ def mock_metrics():
         tts_characters,
         tts_errors,
         tts_latency_ms,
+        tts_time_to_first_audio_ms,
         turn_duration_ms,
         turn_trailing_silence_ms,
         video_detections,
@@ -62,6 +73,7 @@ def mock_metrics():
         vlm_inferences,
         vlm_input_tokens,
         vlm_output_tokens,
+        vlm_time_to_first_token_ms,
     ]
     patches = []
     try:
@@ -107,6 +119,7 @@ class TestMetricsCollector:
             5, {"provider": "openai", "model": "gpt-4"}
         )
         assert collector.agent_metrics.llm_latency_ms__avg.value() == 150
+        assert collector.agent_metrics.llm_latency_ms__avg.count == 1
         assert collector.agent_metrics.llm_time_to_first_token_ms__avg.value() == 50
         assert collector.agent_metrics.llm_input_tokens__total.value() == 10
         assert collector.agent_metrics.llm_output_tokens__total.value() == 5
@@ -157,6 +170,7 @@ class TestMetricsCollector:
                 "error_code": "BAD_REQUEST",
             },
         )
+        assert collector.agent_metrics.llm_errors__total.value() == 1
 
     def test_on_stt_transcript(self, collector):
         collector.on_stt_transcript(
@@ -191,16 +205,21 @@ class TestMetricsCollector:
                 "error_code": "CONNECTION_ERROR",
             },
         )
+        assert collector.agent_metrics.stt_errors__total.value() == 1
 
     def test_on_tts_synthesis(self, collector):
         collector.on_tts_synthesis(
             provider="cartesia",
             synthesis_time_ms=50.0,
+            time_to_first_audio_ms=20.0,
             audio_duration_ms=1500.0,
             character_count=len("Hello world"),
         )
 
         tts_latency_ms.record.assert_called_once_with(50.0, {"provider": "cartesia"})
+        tts_time_to_first_audio_ms.record.assert_called_once_with(
+            20.0, {"provider": "cartesia"}
+        )
         tts_audio_duration_ms.record.assert_called_once_with(
             1500.0, {"provider": "cartesia"}
         )
@@ -208,6 +227,7 @@ class TestMetricsCollector:
             len("Hello world"), {"provider": "cartesia"}
         )
         assert collector.agent_metrics.tts_latency_ms__avg.value() == 50.0
+        assert collector.agent_metrics.tts_time_to_first_audio_ms__avg.value() == 20.0
         assert collector.agent_metrics.tts_audio_duration_ms__total.value() == 1500.0
         assert collector.agent_metrics.tts_characters__total.value() == len(
             "Hello world"
@@ -228,6 +248,7 @@ class TestMetricsCollector:
                 "error_code": "SYNTHESIS_ERROR",
             },
         )
+        assert collector.agent_metrics.tts_errors__total.value() == 1
 
     def test_on_turn_ended(self, collector):
         collector.on_turn_ended(
@@ -242,6 +263,7 @@ class TestMetricsCollector:
         turn_trailing_silence_ms.record.assert_called_once_with(
             500.0, {"provider": "smart_turn"}
         )
+        assert collector.agent_metrics.turns__total.value() == 1
         assert collector.agent_metrics.turn_duration_ms__avg.value() == 3500.0
         assert collector.agent_metrics.turn_trailing_silence_ms__avg.value() == 500.0
 
@@ -250,6 +272,7 @@ class TestMetricsCollector:
             provider="moondream",
             model="moondream-cloud",
             latency_ms=200.0,
+            time_to_first_token_ms=40.0,
             input_tokens=100,
             output_tokens=20,
             frames_processed=5,
@@ -260,6 +283,9 @@ class TestMetricsCollector:
         )
         vlm_inference_latency_ms.record.assert_called_once_with(
             200.0, {"provider": "moondream", "model": "moondream-cloud"}
+        )
+        vlm_time_to_first_token_ms.record.assert_called_once_with(
+            40.0, {"provider": "moondream", "model": "moondream-cloud"}
         )
         video_frames_processed.add.assert_called_once_with(
             5, {"provider": "moondream", "model": "moondream-cloud"}
@@ -273,6 +299,7 @@ class TestMetricsCollector:
 
         assert collector.agent_metrics.vlm_inferences__total.value() == 1
         assert collector.agent_metrics.vlm_inference_latency_ms__avg.value() == 200.0
+        assert collector.agent_metrics.vlm_time_to_first_token_ms__avg.value() == 40.0
         assert collector.agent_metrics.video_frames_processed__total.value() == 5
         assert collector.agent_metrics.vlm_input_tokens__total.value() == 100
         assert collector.agent_metrics.vlm_output_tokens__total.value() == 20
@@ -292,6 +319,7 @@ class TestMetricsCollector:
                 "error_code": "INFERENCE_ERROR",
             },
         )
+        assert collector.agent_metrics.vlm_errors__total.value() == 1
 
     def test_on_video_detection(self, collector):
         collector.on_video_detection(
@@ -324,6 +352,37 @@ class TestMetricsCollector:
     def test_on_realtime_user_transcription(self, collector):
         collector.on_realtime_user_transcription(provider="openai")
         assert collector.agent_metrics.realtime_user_transcriptions__total.value() == 1
+
+    def test_on_realtime_ttfa_and_session(self, collector):
+        collector.on_realtime_session_started(provider="openai")
+        realtime_sessions.add.assert_called_once_with(1, {"provider": "openai"})
+
+        collector.on_realtime_time_to_first_audio(
+            provider="openai", time_to_first_audio_ms=120.0
+        )
+        realtime_time_to_first_audio_ms.record.assert_called_once_with(
+            120.0, {"provider": "openai"}
+        )
+        assert (
+            collector.agent_metrics.realtime_time_to_first_audio_ms__avg.value()
+            == 120.0
+        )
+
+        collector.on_realtime_response_completed(provider="openai")
+        assert collector.agent_metrics.realtime_responses__total.value() == 1
+        realtime_responses.add.assert_called_once_with(1, {"provider": "openai"})
+
+        collector.on_realtime_session_ended(provider="openai", duration_ms=5000.0)
+        realtime_session_duration_ms.record.assert_called_once_with(
+            5000.0, {"provider": "openai"}
+        )
+        assert (
+            collector.agent_metrics.realtime_session_duration_ms__avg.value() == 5000.0
+        )
+
+    def test_on_realtime_error(self, collector):
+        collector.on_realtime_error(provider="openai", error_type="TimeoutError")
+        assert collector.agent_metrics.realtime_errors__total.value() == 1
 
     def test_hierarchy_emits_otel_only_at_root(self, mock_metrics):
         parent = MetricsCollector()
@@ -390,7 +449,19 @@ class TestAgentMetrics:
         metrics = AgentMetrics()
         metrics_dict = metrics.to_dict()
         all_fields = [f.name for f in dataclasses.fields(AgentMetrics)]
-        assert set(all_fields) == set(metrics_dict.keys())
+        assert set(all_fields).issubset(set(metrics_dict.keys()))
+        # Companion counts for every average field.
+        for name in all_fields:
+            if name.endswith("__avg"):
+                assert metrics.count_field_name(name) in metrics_dict
+
+    def test_to_dict_includes_sample_counts(self):
+        metrics = AgentMetrics()
+        metrics.llm_latency_ms__avg.update(100)
+        metrics.llm_latency_ms__avg.update(200)
+        data = metrics.to_dict(fields=["llm_latency_ms__avg"])
+        assert data["llm_latency_ms__avg"] == 150.0
+        assert data["llm_latency_ms__count"] == 2
 
     def test_to_dict_some_fields_success(self):
         metrics = AgentMetrics()
@@ -402,3 +473,19 @@ class TestAgentMetrics:
         metrics = AgentMetrics()
         with pytest.raises(ValueError, match="Unknown field: unknown_field"):
             metrics.to_dict(fields=["unknown_field"])
+
+    def test_infer_mode_pipeline(self):
+        metrics = AgentMetrics()
+        metrics.llm_latency_ms__avg.update(100)
+        assert metrics.infer_mode() == "pipeline"
+
+    def test_infer_mode_realtime(self):
+        metrics = AgentMetrics()
+        metrics.realtime_responses__total.inc(1)
+        assert metrics.infer_mode() == "realtime"
+
+    def test_infer_mode_hybrid(self):
+        metrics = AgentMetrics()
+        metrics.stt_latency_ms__avg.update(50)
+        metrics.realtime_time_to_first_audio_ms__avg.update(80)
+        assert metrics.infer_mode() == "hybrid"

--- a/tests/test_tts_base.py
+++ b/tests/test_tts_base.py
@@ -158,6 +158,10 @@ class TestTTS:
         assert tts.metrics.agent_metrics.tts_characters__total.value() == 5
         assert tts.metrics.agent_metrics.tts_audio_duration_ms__total.value() > 0
         assert tts.metrics.agent_metrics.tts_latency_ms__avg.value() is not None
+        assert (
+            tts.metrics.agent_metrics.tts_time_to_first_audio_ms__avg.value()
+            is not None
+        )
 
     async def test_send_iter_error_raises(self):
         tts = DummyTTSError()


### PR DESCRIPTION
## Why

- metrics were missing a few key things (e.g. realtime stats, time-to-first-answer from LLMs, realtime models, VLMs)
- we only had averages, no info about the number of data points
- no final snapshot (so when evaluating after a call, each consumer would have had to keep track of each emitted metrics event)
- **advantages**
    - better debugging (more metrics + see all metrics at the end of a call)
    - good tracking across all settings (STT -> LLM -> TTS, realtime, VLM)
    - don't need Prometheus setup for solid metrics support

## Changes

- we have richer session metrics now
    - for every average we have a timestamp
    - turn count + total errors encountered
    - TTS: total latency + time-to-first-audio (TTFA)
    - Realtime: TTFA, session duration, response counts
    - VLM: TTFT( time-to-first-token)
- at the end of a call we deliver a `call_metrics_summary` event with all data (not changing the existing `agent_metrics` broadcast event)
 