### PR TITLE
fix(ci): constrain build-time Cython to <3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ vision-agents-plugins-speechify = { workspace = true }
 # vogent-turn requires numpy<2.0, so we override to use 1.26.x
 override-dependencies = ["numpy>=1.26.0,<2.0"]
 
+# curated-tokenizers 0.0.9 (kokoro -> misaki[en] -> spacy-curated-transformers)
+# ships no cp313 wheels, so it is built from source. Its build requirement is an
+# unpinned `cython>=0.25` and Cython 3.3 crashes cythonizing `_bbpe.pyx`.
+build-constraint-dependencies = ["cython<3.3"]
+
 # Store uv cache in project directory for better sandboxing
 cache-dir = ".uv-cache"
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,7 @@ members = [
     "vision-agents-plugins-xai",
 ]
 overrides = [{ name = "numpy", specifier = ">=1.26.0,<2.0" }]
+build-constraints = [{ name = "cython", specifier = "<3.3" }]
 
 [manifest.dependency-groups]
 dev = [


### PR DESCRIPTION
## Why

CI on `main` is red. Both the `CI (unit)` lint job and every `Python compatibility check` matrix job fail during `uv sync` with a Cython compiler crash:

```
[1/3] Cythonizing curated_tokenizers/_bbpe.pyx
TypeError: 'NoneType' object is unsliceable
Cython.Compiler.Errors.CompileError: curated_tokenizers/_bbpe.pyx
hint: `curated-tokenizers` (v0.0.9) was included because `vision-agents-plugins-kokoro` depends on `misaki[en]` (v0.9.4) which depends on `spacy-curated-transformers` (v0.3.1) which depends on `curated-tokenizers`
```

`curated-tokenizers` 0.0.9 only publishes cp312 wheels, so CI's Python 3.13.9 has to build it from source. Its build backend requires an unpinned `cython>=0.25`, so it now picks up Cython 3.3.0 (released 2026-08-22), which crashes cythonizing `_bbpe.pyx`. I verified locally that the same source build succeeds on Python 3.13 with Cython 3.2.9 and reproduces the exact CI crash with 3.3.0.

Worth noting for anyone bisecting: this is not a regression from #639, and nothing in that PR is at fault. The breakage has been latent since Cython 3.3.0 shipped. `astral-sh/setup-uv` derives its cache key from `**/pyproject.toml` and `**/uv.lock`, so as long as those files were untouched CI kept restoring a `curated-tokenizers` wheel built before Cython 3.3 existed. #639 was simply the first PR after Aug 22 to touch the root `pyproject.toml` and `uv.lock`, which invalidated that cache and forced the rebuild. Any subsequent dependency change would have hit the same wall.

Bumping `spacy-curated-transformers` to 2.x would pull `curated-tokenizers` 2.0.1, which does ship cp313 wheels and would remove the source build entirely. That path is not viable here: 2.x requires `thinc>=9.0.0.dev4`, which conflicts with the `thinc<8.4` pin coming from `spacy` 3.x.

## Changes

- Add `build-constraint-dependencies = ["cython<3.3"]` to `[tool.uv]` in the workspace root. This is build-time only, applies to source builds within this workspace, and does not affect resolved runtime dependencies or published wheels.

The only sdist-only packages in the lock are `docopt`, `forbiddenfruit` and `tls-sig-api-v2`, none of which use Cython, so nothing in the workspace needs Cython 3.3+ to build.

Made with [Cursor](https://cursor.com)