### PR TITLE
fix: stop thought leakage and dropped tools on interrupt

### DIFF
--- a/acceleration/internal/agent/agent.go
+++ b/acceleration/internal/agent/agent.go
@@ -255,6 +255,13 @@ type Agent struct {
 	// a provider is still sending. It holds one entry per interruption and lives only as
 	// long as the call.
 	abandoned map[string]struct{}
+	// settling is the turn an interruption closed that has not yet reported its tool
+	// calls. The follow-up waits for it so those calls land in history before the next
+	// user turn.
+	settling string
+	// pending is the follow-up held while settling completes. Presence means the caller
+	// changed what they asked, so the abandoned tools are cancelled rather than run.
+	pending *pendingTurn
 	// utterances counts syntheses that have not settled, so Finish knows when the agent
 	// has stopped talking.
 	utterances int
@@ -313,6 +320,15 @@ type Agent struct {
 
 	running   sync.WaitGroup
 	closeOnce sync.Once
+}
+
+// pendingTurn is a follow-up held until an interrupted reply has settled.
+type pendingTurn struct {
+	turnID      string
+	participant stt.Participant
+	text        string
+	listened    heard
+	note        string
 }
 
 // New validates the options and returns an Agent. It opens nothing; Join does that.
@@ -1234,6 +1250,17 @@ func (a *Agent) respondTurn(
 		a.mu.Unlock()
 		return errors.New("agent: not joined")
 	}
+	if a.settling != "" {
+		a.pending = &pendingTurn{
+			turnID:      turnID,
+			participant: participant,
+			text:        text,
+			listened:    listened,
+			note:        note,
+		}
+		a.mu.Unlock()
+		return nil
+	}
 	a.history = append(a.history, llm.Message{Role: llm.User, Content: text})
 	history := append([]llm.Message(nil), a.history...)
 
@@ -1434,6 +1461,9 @@ func (a *Agent) handle(event llm.Event) {
 
 	case llm.ResponseCompleted:
 		if !a.speaking(typed.Response.ID) {
+			if a.finishAbandoned(typed.Response) {
+				return
+			}
 			// The reply the chunker is holding is only cleared by the turn it belongs
 			// to, so a response arriving late for an abandoned one cannot cut the turn
 			// after it short.
@@ -1558,6 +1588,8 @@ func (a *Agent) finish(response llm.Response) {
 	currentHarness := a.harness
 	a.mu.Unlock()
 
+	a.logSettled(response, said != "", calls)
+
 	// A provider that kept this reply can be asked to carry on from it next turn rather
 	// than read the conversation again.
 	if currentHarness != nil {
@@ -1596,6 +1628,88 @@ func (a *Agent) finish(response llm.Response) {
 	a.respondQueued()
 	// A note that landed while this reply was being written waited for it to finish.
 	a.followUp()
+}
+
+// finishAbandoned records an interrupted reply so its tool calls still land in history.
+//
+// If the caller only barged in, the tools still run. If they already asked something
+// else, the tools are cancelled with a result the provider can match, and the follow-up
+// is answered after that.
+func (a *Agent) finishAbandoned(response llm.Response) bool {
+	a.mu.Lock()
+	if a.settling != response.ID {
+		a.mu.Unlock()
+		return false
+	}
+	a.mu.Unlock()
+
+	asked := a.harness.TakeAsked()
+	calls := append(append([]llm.ToolCall(nil), response.ToolCalls...), asked...)
+	said := strings.TrimSpace(a.spoken.String())
+	a.resetTurn()
+
+	a.mu.Lock()
+	a.generating = false
+	pending := a.pending
+	a.pending = nil
+	a.settling = ""
+	if said != "" || len(calls) > 0 {
+		a.history = append(a.history, llm.Message{
+			Role:      llm.Assistant,
+			Content:   said,
+			ToolCalls: calls,
+		})
+	}
+	currentHarness := a.harness
+	a.mu.Unlock()
+
+	a.logSettled(response, said != "", calls)
+
+	if pending != nil {
+		for _, call := range calls {
+			a.cancelledToolResult(call)
+		}
+		if err := a.respondTurn(pending.turnID, pending.participant, pending.text, pending.listened, pending.note); err != nil {
+			a.fail(err, "llm")
+		}
+		return true
+	}
+
+	if currentHarness != nil && len(calls) > 0 {
+		pendingCount := 0
+		tools := a.availableTools()
+		for _, call := range calls {
+			if _, known := tools.Lookup(call.Name); known {
+				pendingCount++
+			}
+		}
+		a.mu.Lock()
+		a.pendingTools += pendingCount
+		a.mu.Unlock()
+		currentHarness.Requested(response.ID, calls)
+	}
+	a.respondQueued()
+	a.followUp()
+	return true
+}
+
+// cancelledToolResult records that an interrupted tool did not run, so the next request
+// still has a result for every call the model made.
+func (a *Agent) cancelledToolResult(call llm.ToolCall) {
+	a.resolveTool(call, "cancelled: the caller changed what they asked before this could run")
+}
+
+// logSettled records every completion with whether it spoke and which tools it asked for.
+func (a *Agent) logSettled(response llm.Response, spoken bool, calls []llm.ToolCall) {
+	names := make([]string, 0, len(calls))
+	for _, call := range calls {
+		names = append(names, call.Name)
+	}
+	a.logger.Info("llm reply settled",
+		"turn", response.ID,
+		"status", response.Status,
+		"spoken", spoken,
+		"tools", names)
 }
 
 // fillsPause reports whether a turn that said nothing should say something before the
@@ -1876,7 +1990,7 @@ func (a *Agent) followUp() {
 // earned -- so a caller who waited only for the first would talk over the rest.
 func (a *Agent) Busy() bool {
 	a.mu.Lock()
-	working := a.generating || a.utterances > 0
+	working := a.generating || a.utterances > 0 || a.settling != "" || a.pending != nil
 	current := a.harness
 	a.mu.Unlock()
 
@@ -1988,6 +2102,9 @@ func (a *Agent) interrupt(participant stt.Participant) {
 		return
 	}
 	a.abandoned[turnID] = struct{}{}
+	if a.generating || a.streams[turnID] != nil || a.generatingCancel[turnID] != nil {
+		a.settling = turnID
+	}
 	a.speakingTurn = ""
 	a.generating = false
 	a.saying = ""

--- a/acceleration/internal/agent/telephony_test.go
+++ b/acceleration/internal/agent/telephony_test.go
@@ -496,6 +496,72 @@ func (s *AgentSuite) TestPressingAMenuOptionSilentlyIsNotGivenAFillerEither() {
 		"the agent talked over the menu it had just pressed at")
 }
 
+func (s *AgentSuite) TestAnInterruptedReplyStillRunsItsTools() {
+	s.ownsTools("order 12 ships tomorrow")
+	s.join(true)
+	s.model.reply = nil
+	s.voice.silent = true
+	participant := stt.Participant{ID: "alice"}
+	s.speak(participant)
+
+	s.says(participant, "where is my order")
+	s.eventually(func() bool { return len(s.model.requests()) == 1 }, "the first reply never started")
+	turn := s.model.requests()[0].ID
+	s.model.script(turn).ToolCalls(llm.ToolCall{
+		ID: "call-1", Name: "lookup_order", Arguments: `{"order":"12"}`,
+	})
+
+	s.mutters(participant, "uh huh wait")
+	s.eventually(func() bool { return countOf[Interrupted](s.reported()) == 1 },
+		"talking over the agent should abandon the reply")
+	s.model.finishes(turn)
+
+	s.eventually(func() bool { return len(s.runner.asked()) == 1 },
+		"barging in is not a reason to drop the tool the model already asked for")
+	s.Equal(`{"order":"12"}`, s.runner.asked()[0].Arguments)
+
+	s.eventually(func() bool {
+		for _, message := range s.history() {
+			if message.Role == llm.ToolResult && message.ToolCallID == "call-1" {
+				return true
+			}
+		}
+		return false
+	}, "the tool result never reached the conversation")
+}
+
+func (s *AgentSuite) TestAnInterruptedReplyCancelsItsToolsWhenTheCallerChangesTheAsk() {
+	s.ownsTools("order 12 ships tomorrow")
+	s.join(true)
+	s.model.reply = nil
+	s.model.then = []string{"A table for two, coming up."}
+	s.voice.silent = true
+	participant := stt.Participant{ID: "alice"}
+	s.speak(participant)
+
+	s.says(participant, "where is my order")
+	s.eventually(func() bool { return len(s.model.requests()) == 1 }, "the first reply never started")
+	turn := s.model.requests()[0].ID
+	s.model.script(turn).ToolCalls(llm.ToolCall{
+		ID: "call-1", Name: "lookup_order", Arguments: `{"order":"12"}`,
+	})
+
+	s.says(participant, "actually I want a table for two tonight")
+	s.eventually(func() bool { return countOf[Interrupted](s.reported()) == 1 },
+		"the new ask should stop the reply in flight")
+	s.model.finishes(turn)
+
+	s.never(func() bool { return len(s.runner.asked()) > 0 },
+		"a tool for the old ask must not run after the caller changed it")
+	s.Contains(s.history(), llm.Message{
+		Role:       llm.ToolResult,
+		Content:    "cancelled: the caller changed what they asked before this could run",
+		ToolCallID: "call-1",
+	})
+	s.eventually(func() bool { return len(s.model.requests()) == 2 },
+		"the new ask was never answered")
+}
+
 func (s *AgentSuite) TestATelephonyToolIsNotHandedToTheCallersRunner() {
 	// The two that act on the call are this process's to run, so a caller cannot quietly
 	// take over what happens when the model says it is transferring somebody.

--- a/acceleration/internal/llm/openaicompat/openaicompat.go
+++ b/acceleration/internal/llm/openaicompat/openaicompat.go
@@ -213,6 +213,8 @@ type puller struct {
 
 	err  error
 	done bool
+
+	thoughts thoughtStripper
 }
 
 // Advance reads one chunk and records what it carried.
@@ -243,7 +245,11 @@ func (p *puller) Advance(w *llm.ResponseWriter) bool {
 	}
 
 	for _, choice := range chunk.Choices {
-		w.OutputText(choice.Delta.Content)
+		spoken := p.thoughts.Add(choice.Delta.Content)
+		if looksLikeThinking(spoken) {
+			p.llm.logger.Info("llm content looks like thinking", "text", spoken)
+		}
+		w.OutputText(spoken)
 		w.ReasoningText(reasoning(choice.Delta.JSON.ExtraFields))
 		for _, call := range choice.Delta.ToolCalls {
 			w.FunctionCall(
@@ -274,6 +280,12 @@ func (p *puller) Close() error {
 // finish releases the upstream and works out what ended it.
 func (p *puller) finish(w *llm.ResponseWriter) {
 	p.done = true
+
+	leftover := p.thoughts.Flush()
+	if looksLikeThinking(leftover) {
+		p.llm.logger.Info("llm content looks like thinking", "text", leftover)
+	}
+	w.OutputText(leftover)
 
 	if err := p.upstream.Err(); err != nil && !errors.Is(err, context.Canceled) {
 		p.err = err

--- a/acceleration/internal/llm/openaicompat/openaicompat_test.go
+++ b/acceleration/internal/llm/openaicompat/openaicompat_test.go
@@ -302,6 +302,31 @@ func (s *OpenAICompatSuite) TestThinkingIsSeparatedFromTheAnswer() {
 	s.Equal("The user said hi, so", thinking, "but it is still available to a caller that wants it")
 }
 
+func (s *OpenAICompatSuite) TestThoughtMarkersInTheAnswerAreNotSpoken() {
+	s.frames = []string{
+		textFrame("<|channel>thought"),
+		textFrame(" I should greet them "),
+		textFrame("<channel|>"),
+		textFrame("Hello there."),
+		usageFrame(11, 0, 20, 0, "stop"),
+	}
+	provider := s.provider(Options{})
+
+	response, events := s.ask(provider, hello())
+
+	s.Equal("Hello there.", response.OutputText, "in-band thought must never be spoken as the reply")
+
+	var spoken string
+	for _, event := range events {
+		if delta, ok := event.(llm.OutputTextDelta); ok {
+			spoken += delta.Delta
+		}
+	}
+	s.Equal("Hello there.", spoken)
+	s.NotContains(spoken, "thought")
+	s.NotContains(spoken, "<channel")
+}
+
 func (s *OpenAICompatSuite) TestInstructionsAreSentAsASystemMessage() {
 	s.frames = []string{textFrame("ok"), usageFrame(5, 0, 1, 0, "stop")}
 	provider := s.provider(Options{})

--- a/acceleration/internal/llm/openaicompat/thought.go
+++ b/acceleration/internal/llm/openaicompat/thought.go
@@ -1,0 +1,269 @@
+package openaicompat
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Markers Gemma and Harmony-style models leak into content instead of the reasoning field.
+const (
+	channelThoughtOpen  = "<|channel>thought"
+	channelThoughtOpen2 = "<|channel|>thought"
+	channelThoughtClose = "<channel|>"
+	channelSwitch       = "<|channel|>"
+	thinkOpen           = "<think>"
+	thinkClose          = "</think>"
+)
+
+// tagHold bounds how much text may be held back waiting for a thought marker to finish.
+const tagHold = 256
+
+type thoughtKind int
+
+const (
+	thoughtNone thoughtKind = iota
+	thoughtChannel
+	thoughtThink
+)
+
+// thoughtStripper takes thought-channel markup out of a streaming reply so it is never
+// spoken. Models that think in-band write <|channel>thought…<channel|>, <think>…</think>,
+// or a leading "thought" / "Thought." instead of using the reasoning field.
+type thoughtStripper struct {
+	pending strings.Builder
+	inside  thoughtKind
+	spoken  bool
+}
+
+// Add takes a content delta and returns the part that may be spoken.
+func (s *thoughtStripper) Add(text string) string {
+	if text == "" {
+		return ""
+	}
+	s.pending.WriteString(text)
+	return s.drain(false)
+}
+
+// Flush releases what is left at the end of a reply. Text held back for a marker that
+// never arrived was only ever text. A thought block that never closed is dropped.
+func (s *thoughtStripper) Flush() string {
+	spoken := s.drain(true)
+	s.pending.Reset()
+	s.inside = thoughtNone
+	s.spoken = false
+	return spoken
+}
+
+func (s *thoughtStripper) drain(flush bool) string {
+	var spoken strings.Builder
+	for {
+		buffered := s.pending.String()
+		if buffered == "" {
+			break
+		}
+
+		if s.inside != thoughtNone {
+			closeAt, closeLen := s.findClose(buffered)
+			if closeAt < 0 {
+				if flush || len(buffered) > tagHold {
+					s.pending.Reset()
+				}
+				break
+			}
+			s.inside = thoughtNone
+			s.reset(buffered[closeAt+closeLen:])
+			continue
+		}
+
+		if !s.spoken {
+			rest, held, stripped := stripLeadingThought(buffered, flush)
+			if stripped {
+				s.reset(rest)
+				continue
+			}
+			if held {
+				break
+			}
+		}
+
+		before, rest, kind, incomplete := splitThoughtOpen(buffered)
+		if incomplete {
+			// Hold the whole buffer, including text before a possible marker, until
+			// the next delta completes it or Flush proves it was only ever text.
+			if flush {
+				spoken.WriteString(buffered)
+				s.spoken = s.spoken || buffered != ""
+				s.pending.Reset()
+			}
+			break
+		}
+		if before != "" {
+			spoken.WriteString(before)
+			s.spoken = true
+		}
+		if kind == thoughtNone {
+			s.reset("")
+			break
+		}
+		s.inside = kind
+		s.reset(rest)
+	}
+	return spoken.String()
+}
+
+func (s *thoughtStripper) reset(text string) {
+	s.pending.Reset()
+	s.pending.WriteString(text)
+}
+
+func (s *thoughtStripper) findClose(text string) (int, int) {
+	switch s.inside {
+	case thoughtThink:
+		if i := strings.Index(text, thinkClose); i >= 0 {
+			return i, len(thinkClose)
+		}
+	case thoughtChannel:
+		closeAt, closeLen := -1, 0
+		if i := strings.Index(text, channelThoughtClose); i >= 0 {
+			closeAt, closeLen = i, len(channelThoughtClose)
+		}
+		if i := strings.Index(text, channelSwitch); i >= 0 && (closeAt < 0 || i < closeAt) {
+			closeAt, closeLen = i, len(channelSwitch)
+		}
+		return closeAt, closeLen
+	}
+	return -1, 0
+}
+
+func splitThoughtOpen(text string) (before, rest string, kind thoughtKind, incomplete bool) {
+	earliest := -1
+	found := thoughtNone
+	opens := []struct {
+		marker string
+		kind   thoughtKind
+	}{
+		{channelThoughtOpen, thoughtChannel},
+		{channelThoughtOpen2, thoughtChannel},
+		{thinkOpen, thoughtThink},
+	}
+	for _, open := range opens {
+		i := strings.Index(text, open.marker)
+		if i >= 0 && (earliest < 0 || i < earliest) {
+			earliest = i
+			found = open.kind
+		}
+	}
+	if earliest >= 0 {
+		marker := thinkOpen
+		if found == thoughtChannel {
+			if strings.HasPrefix(text[earliest:], channelThoughtOpen2) {
+				marker = channelThoughtOpen2
+			} else {
+				marker = channelThoughtOpen
+			}
+		}
+		return text[:earliest], text[earliest+len(marker):], found, false
+	}
+
+	hold := longestOpenPrefix(text)
+	if hold > 0 {
+		return text[:len(text)-hold], text[len(text)-hold:], thoughtNone, true
+	}
+	return text, "", thoughtNone, false
+}
+
+func longestOpenPrefix(text string) int {
+	markers := []string{channelThoughtOpen2, channelThoughtOpen, thinkOpen}
+	hold := 0
+	for n := 1; n <= len(text) && n < len(channelThoughtOpen2); n++ {
+		suffix := text[len(text)-n:]
+		for _, marker := range markers {
+			if strings.HasPrefix(marker, suffix) {
+				hold = n
+				break
+			}
+		}
+	}
+	return hold
+}
+
+// stripLeadingThought removes a leaked "thought" / "Thought." / "Channel thought" at the
+// start of a reply. held is true when more text is needed to know.
+func stripLeadingThought(text string, flush bool) (rest string, held, stripped bool) {
+	trim := 0
+	for trim < len(text) {
+		r, size := decodeLeadingSpace(text[trim:])
+		if r == 0 {
+			break
+		}
+		trim += size
+	}
+	body := text[trim:]
+	if body == "" {
+		if flush {
+			return text, false, false
+		}
+		return text, true, false
+	}
+
+	lower := strings.ToLower(body)
+	for _, prefix := range []string{"channel thought", "thought"} {
+		if !strings.HasPrefix(lower, prefix) {
+			continue
+		}
+		after := body[len(prefix):]
+		if after == "" && !flush {
+			return text, true, false
+		}
+		if after == "" || after[0] == '.' || unicode.IsSpace(rune(after[0])) {
+			if strings.HasPrefix(after, ".") {
+				after = after[1:]
+			}
+			return strings.TrimLeft(after, " \t\n\r"), false, true
+		}
+	}
+
+	if !flush {
+		for _, prefix := range []string{"channel thought", "thought"} {
+			if strings.HasPrefix(strings.ToLower(prefix), strings.ToLower(body)) {
+				return text, true, false
+			}
+		}
+	}
+	return text, false, false
+}
+
+func decodeLeadingSpace(text string) (rune, int) {
+	if text == "" {
+		return 0, 0
+	}
+	r := rune(text[0])
+	if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+		return r, 1
+	}
+	return 0, 0
+}
+
+// looksLikeThinking reports whether text still looks like a thought channel that would
+// be spoken, which is a leak the stripper missed.
+func looksLikeThinking(text string) bool {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return false
+	}
+	lower := strings.ToLower(t)
+	if strings.Contains(lower, "<|channel>thought") ||
+		strings.Contains(lower, "<|channel|>thought") ||
+		strings.Contains(lower, "<channel|>") ||
+		strings.Contains(lower, "<think>") ||
+		strings.Contains(lower, "channel thought") {
+		return true
+	}
+	if strings.HasPrefix(lower, "thought.") || lower == "thought" {
+		return true
+	}
+	if strings.HasPrefix(lower, "thought ") || strings.HasPrefix(lower, "thought\n") {
+		return true
+	}
+	return false
+}

--- a/acceleration/internal/llm/openaicompat/thought_test.go
+++ b/acceleration/internal/llm/openaicompat/thought_test.go
@@ -1,0 +1,63 @@
+package openaicompat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThoughtStripperDropsChannelThought(t *testing.T) {
+	var s thoughtStripper
+	require.Empty(t, s.Add("<|channel>thought I should greet the caller <channel|>"))
+	require.Equal(t, "Hello there.", s.Add("Hello there."))
+}
+
+func TestThoughtStripperDropsThinkTags(t *testing.T) {
+	var s thoughtStripper
+	require.Empty(t, s.Add("<think>plan the reply</think>"))
+	require.Equal(t, "Sure.", s.Add("Sure."))
+}
+
+func TestThoughtStripperDropsALeadingThoughtMarker(t *testing.T) {
+	var s thoughtStripper
+	require.Equal(t, "I can help with that.", s.Add("Thought. I can help with that."))
+}
+
+func TestThoughtStripperDropsALeadingChannelThoughtWord(t *testing.T) {
+	var s thoughtStripper
+	require.Equal(t, "Hello.", s.Add("Channel thought\nHello."))
+}
+
+func TestThoughtStripperHandlesMarkersSplitAcrossDeltas(t *testing.T) {
+	var s thoughtStripper
+	require.Empty(t, s.Add("<|chan"))
+	require.Empty(t, s.Add("nel>thought\nneed a table\n"))
+	require.Empty(t, s.Add("<channel"))
+	require.Equal(t, "One moment.", s.Add("|>One moment."))
+}
+
+func TestThoughtStripperFlushSpeaksAnUnfinishedMarker(t *testing.T) {
+	var s thoughtStripper
+	require.Empty(t, s.Add("Hi<"))
+	require.Equal(t, "Hi<", s.Flush())
+}
+
+func TestThoughtStripperFlushDropsAnUnclosedThought(t *testing.T) {
+	var s thoughtStripper
+	require.Empty(t, s.Add("<think>still thinking"))
+	require.Empty(t, s.Flush())
+}
+
+func TestThoughtStripperLeavesOrdinarySpeechAlone(t *testing.T) {
+	var s thoughtStripper
+	require.Equal(t, "Thanks, I will check.", s.Add("Thanks, I will check."))
+	require.Empty(t, s.Flush())
+}
+
+func TestLooksLikeThinking(t *testing.T) {
+	require.True(t, looksLikeThinking("Thought. I should call a tool."))
+	require.True(t, looksLikeThinking("Channel thought"))
+	require.True(t, looksLikeThinking("<|channel>thought hidden <channel|>"))
+	require.False(t, looksLikeThinking("One moment, checking."))
+	require.False(t, looksLikeThinking(""))
+}

--- a/benchmark/agents/contracts/restaurant.prompt
+++ b/benchmark/agents/contracts/restaurant.prompt
@@ -17,3 +17,7 @@ workaround.
 
 Never say a reservation is booked until create_reservation returns success. After a
 successful booking, read back name, time, party size, and allergen from that result.
+After check_availability returns an open table, call create_reservation in the same turn
+when name and allergen are known. Do not ask whether to book.
+After lookup_menu, call create_order in the same turn when the items and allergen are
+known. Do not ask whether to place it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Restaurant bench runs were failing because Gemma spoke thought-channel markup (`Thought.`, `Channel thought`) and interrupted replies dropped in-flight tool calls.

## Changes
- Strip `<|channel>thought`, `<think>`, and a leading leaked `thought`/`Thought.` from OpenAI-compat content before it is spoken.
- Interrupted replies still record tool calls in history. Barge-in executes them; a changed ask injects cancelled tool results.
- Restaurant prompt: after `check_availability` / `lookup_menu` succeed, call `create_reservation` / `create_order` in the same turn when name+allergen / items+allergen are known.

## Gemma k=1 validation
Run `20260909T014745Z`, restaurant pack, Flux STT, `gemma/gemma-4-26B-A4B-it`.

**Pass 3/8.** adversarial / coherence / tool_filler pass; entity_dense, golden, interrupt, noise_kitchen, selectivity fail.

V2V P50 **1520 ms** (n=22). False cutoffs **1.00**/call.

Thought-channel leakage: **gone from speech** (no `Thought.` / `Channel thought` in transcripts). One rare router log leftover `text=<channel|>`.

Log: `/tmp/va-bench-gemma-after.log`. Writeup: `benchmark/out/gemma-k1-after.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40fc7956-e6d7-4d2b-a620-95aedb99adbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40fc7956-e6d7-4d2b-a620-95aedb99adbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

